### PR TITLE
Add support for DataLoader pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,12 @@ module.exports = {
 ## Examples
 
 - [Simple](examples/simple/index.js)
+  - `npm run dev`
 - [Full](examples/full/index.js)
-
+  - `npm run dev full`
+- [Full With Dataloader](examples/full-dataloader/index.js)
+  - set `DATALOADER` environment variable to `"true"`
+  - `npm run dev full`
 # Test
 ```
 $ npm test

--- a/examples/full/index.js
+++ b/examples/full/index.js
@@ -1,11 +1,12 @@
 "use strict";
 
 const fs = require("fs");
+const { Kind } = require("graphql");
 const { ServiceBroker } = require("moleculer");
 const ApiGateway = require("moleculer-web");
 const { ApolloService } = require("../../index");
 
-const broker = new ServiceBroker({ logLevel: "info"/*, transporter: "NATS"*/ });
+const broker = new ServiceBroker({ logLevel: process.env.LOGLEVEL || "info"/*, transporter: "NATS"*/ });
 
 broker.createService({
 	name: "api",
@@ -78,7 +79,7 @@ broker.createService({
 			fs.writeFileSync(__dirname + "/generated-schema.gql", schema, "utf8");
 			this.logger.info("Generated GraphQL schema:\n\n" + schema);
 		}
-	}	
+	}
 });
 
 broker.loadServices(__dirname);

--- a/examples/full/posts.service.js
+++ b/examples/full/posts.service.js
@@ -9,7 +9,7 @@ const posts = [
 	{ id: 3, title: "Third post", author: 2, votes: 1, voters: [5], createdAt:new Date("2018-02-23T22:24:28")  },
 	{ id: 4, title: "4th post", author: 3, votes: 3, voters: [4,1,2], createdAt: new Date("2018-10-23T10:33:00") },
 	{ id: 5, title: "5th post", author: 5, votes: 1, voters: [4], createdAt: new Date("2018-11-24T21:15:30") },
-]
+];
 
 module.exports = {
 	name: "posts",
@@ -33,12 +33,14 @@ module.exports = {
 				Post: {
 					author: {
 						action: "users.resolve",
+						dataLoader: process.env.DATALOADER === "true",
 						rootParams: {
 							"author": "id"
 						}
 					},
 					voters: {
 						action: "users.resolve",
+						dataLoader: process.env.DATALOADER === "true",
 						rootParams: {
 							"voters": "id"
 						}
@@ -58,7 +60,7 @@ module.exports = {
 				limit: { type: "number", optional: true }
 			},
 			graphql: {
-				query: `posts(limit: Int): [Post]`
+				query: "posts(limit: Int): [Post]"
 			},
 			handler(ctx) {
 				let result = _.cloneDeep(posts);
@@ -151,18 +153,18 @@ module.exports = {
 				filter: "posts.vote.filter"
 			},
 			handler(ctx) {
-				return ctx.params.payload.type
+				return ctx.params.payload.type;
 			}
 		},
 		"vote.filter": {
 			params: { userID: "number", payload: "object" },
 			handler(ctx) {
-				return ctx.params.payload.userID === ctx.params.userID
+				return ctx.params.payload.userID === ctx.params.userID;
 			}
 		},
 		error: {
 			handler() {
-				throw new Error('Oh look an error !')
+				throw new Error("Oh look an error !");
 			}
 		},
 	},
@@ -170,6 +172,6 @@ module.exports = {
 	methods: {
 		findByID(id) {
 			return posts.find(post => post.id == id);
-		}		
+		}
 	}
 };

--- a/examples/full/users.service.js
+++ b/examples/full/users.service.js
@@ -3,12 +3,12 @@
 const _ = require("lodash");
 
 const users = [
-	{ id: 1, name: "Genaro Krueger", birthday: new Date('1975-12-17') },
-	{ id: 2, name: "Nicholas Paris", birthday: new Date('1981-01-27') },
-	{ id: 3, name: "Quinton Loden", birthday: new Date('1995-03-22') },
-	{ id: 4, name: "Bradford Knauer", birthday: new Date('2008-11-01') },
-	{ id: 5, name: "Damien Accetta", birthday: new Date('1959-08-07') },
-]
+	{ id: 1, name: "Genaro Krueger", birthday: new Date("1975-12-17") },
+	{ id: 2, name: "Nicholas Paris", birthday: new Date("1981-01-27") },
+	{ id: 3, name: "Quinton Loden", birthday: new Date("1995-03-22") },
+	{ id: 4, name: "Bradford Knauer", birthday: new Date("2008-11-01") },
+	{ id: 5, name: "Damien Accetta", birthday: new Date("1959-08-07") },
+];
 
 module.exports = {
 	name: "users",
@@ -34,16 +34,16 @@ module.exports = {
 							"id": "userID"
 						}
 					},
-                    postCount: {
-                        // Call the "posts.count" action
-                        action: "posts.count",
-                        // Get `id` value from `root` and put it into `ctx.params.query.author`
-                        rootParams: {
-                            "id": "query.author"
-                        }
-                    }					
+					postCount: {
+						// Call the "posts.count" action
+						action: "posts.count",
+						// Get `id` value from `root` and put it into `ctx.params.query.author`
+						rootParams: {
+							"id": "query.author"
+						}
+					}
 				}
-			}			
+			}
 		}
 	},
 	actions: {
@@ -74,6 +74,7 @@ module.exports = {
 				]
 			},
 			handler(ctx) {
+				this.logger.debug("resolve action called.", { params: ctx.params });
 				if (Array.isArray(ctx.params.id)) {
 					return _.cloneDeep(ctx.params.id.map(id => this.findByID(id)));
 				} else {

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -33,11 +33,11 @@ broker.createService({
 		"graphql.schema.updated"({ schema }) {
 			this.logger.info("Generated GraphQL schema:\n\n" + schema);
 		}
-	}	
+	}
 });
 
 broker.createService({
-	name: "greeter", 
+	name: "greeter",
 
 	actions: {
 		hello: {
@@ -45,7 +45,7 @@ broker.createService({
 				query: "hello: String!"
 			},
 			handler() {
-				return "Hello Moleculer!"
+				return "Hello Moleculer!";
 			}
 		},
 		welcome: {
@@ -62,18 +62,18 @@ broker.createService({
 				tags: ["TEST"]
 			},
 			handler(ctx) {
-				return ctx.params.payload
+				return ctx.params.payload;
 			}
 		}
 	}
-})
+});
 
 broker.start()
 	.then(async () => {
 		broker.repl();
 
 		const res = await broker.call("api.graphql", {
-			query: `query { hello }`
+			query: "query { hello }"
 		});
 
 		let counter = 1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,6 +1706,11 @@
         }
       }
     },
+    "dataloader": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
+      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3004,12 +3009,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3024,17 +3031,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3151,7 +3161,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3163,6 +3174,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3177,6 +3189,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3184,12 +3197,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3208,6 +3223,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3288,7 +3304,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3300,6 +3317,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3421,6 +3439,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@apollographql/graphql-playground-html": "1.6.6",
     "accept": "3.1.3",
     "apollo-server-core": "2.3.4",
+    "dataloader": "1.4.0",
     "graphql-subscriptions": "^1.0.0",
     "graphql-tools": "4.0.4",
     "graphql-upload": "^8.0.4",


### PR DESCRIPTION
This PR adds support for using the [DataLoader](https://www.npmjs.com/package/dataloader) [pattern](https://www.apollographql.com/docs/graphql-tools/connectors.html#dataloader) to allow for resolving in batches.  Using this pattern, rather than a moleculer action being called repetitively, it can be called a single time, in batch format, resolving for multiple parent types at once.  The upshot of this is that expensive operations (such as database accesses) can be done a single time rather than multiple times drastically improving performance.

The API to this is a very simple addition to the existing resolver API.  An optional Boolean parameter, `dataLoader`, can be provided to the resolver object.  If this parameter is truthy, a new `DataLoader` instance associated with the moleculer action will be created and loaded in to the GraphQL context for each new request.  This `DataLoader` instance will set to call the action provided as the resolver `action` (existing property) as a batch.  The resolver function will, instead of calling the moleculer action, call the DataLoader's `load` function with the value located at the first `rootParams` property (existing property).  When the DataLoader calls in batch format, it will pass all of the previously loaded values to the moleculer action with a param key of the first `rootParams` value in the key value pair.

For instance, for a resolver formatted like this:
```js
resolvers: {
  Post: {
    author: {
      action: "users.resolve",
      dataLoader: true,
      rootParams: {
       "author": "id"
      }
     },
...
}
```

The DataLoader batch function will call moleculer action `users.resolve` with a `params` value of `{ id: ["author1", "author2", ...] }`.

The existing `full` example has been adjusted to allow for running the examples both with and without dataloader.  By setting environment variable `DATALOADER` to `"true"` and running the full example, the behavior of dataloader can be witnessed.  In addition, the full example was adjusted to set the logging level based on the `LOGLEVEL` environment variable. Setting the `LOGLEVEL` to `"debug"` will allow a visual for how the actions are being called and one can visibly see the difference between using `DataLoader` and not using `DataLoader`.

One point of note with respect to the `rootParams` object.  Without using dataloaders, every property of the `rootParams` object is utilized and passed to the moleculer action.  However, with dataloaders, the `load()` function can only accept a single value.  Therefore, if `dataLoader` is truthy, only the first key/value pair from `rootParams` will be utilized.  Any other key/value pairs specified will be ignored.

Finally, I discovered that some of the example code wasn't respecting the eslint rules for the repo (e.g. missing semicolons, spacing issues, etc.) and fixed those while I was modifying the examples.

Resolves #13 