### PR TITLE
Trim action resolver names

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -222,7 +222,7 @@ module.exports = function(mixinOptions) {
 									const def = action.graphql;
 
 									if (def.query) {
-										const name = def.query.split(/[(:]/g)[0];
+										const name = def.query.trim().split(/[(:]/g)[0];
 										queries.push(def.query);
 										if (!resolver["Query"]) resolver.Query = {};
 										resolver.Query[name] = this.createActionResolver(action.name);
@@ -232,14 +232,14 @@ module.exports = function(mixinOptions) {
 										types.push(def.type);
 
 									if (def.mutation) {
-										const name = def.mutation.split(/[(:]/g)[0];
+										const name = def.mutation.trim().split(/[(:]/g)[0];
 										mutations.push(def.mutation);
 										if (!resolver["Mutation"]) resolver.Mutation = {};
 										resolver.Mutation[name] = this.createActionResolver(action.name);
 									}
 
 									if (def.subscription) {
-										const name = def.subscription.split(/[(:]/g)[0];
+										const name = def.subscription.trim().split(/[(:]/g)[0];
 										subscriptions.push(def.subscription);
 										if (!resolver["Subscription"]) resolver.Subscription = {};
 										resolver.Subscription[name] = this.createAsyncIteratorResolver(action.name, def.tags, def.filter);


### PR DESCRIPTION
When writing graphql query definitions, mutations, or subscriptions, it makes things easier to use multi-line strings for clarity.  Apollo does not care if there are whitespace characters present.  Unfortunately, because the string supplied is split to make the name of the resolver, the resolver name ends up with extra whitespace and does not match up and thus the schema generation fails.

For instance, a query definition like:
```js
graphql: {
  query: `
    getWorkspaces(
      name: [String]
      clientId: [String]
      sort: [String]
      pageSize: Int
      page: Int
    ) : [Workspace]
  `,
},
```
is a bit easier to read and maintain.  This PR simply adds a `trim()` prior to the splitting of the string and acquisition of the resolver's name to allow for this type of formatting.