### PR TITLE
Multiple mutations per resolver

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -232,10 +232,13 @@ module.exports = function(mixinOptions) {
 										types.push(def.type);
 
 									if (def.mutation) {
-										const name = def.mutation.trim().split(/[(:]/g)[0];
-										mutations.push(def.mutation);
+										let mutation = def.mutation.trim().split(/[\n]/g).map(m => m.trim())
+										let names = mutation.map(m => m.trim().split(/[(:]/g)[0])
 										if (!resolver["Mutation"]) resolver.Mutation = {};
-										resolver.Mutation[name] = this.createActionResolver(action.name);
+										mutations.push(...mutation);
+										names.forEach(name => {
+											resolver.Mutation[name] = this.createActionResolver(action.name);	
+										})
 									}
 
 									if (def.subscription) {


### PR DESCRIPTION
Multiple mutations per resolver can be defined if they are separated by a new line character. 

For instance:

```insert: {
	graphql: {
		mutation: `
			insertSchedule(entity: ScheduleInput): Schedule
			insertSchedules(entities: [ScheduleInput]): [Schedule]
		`
	},
},```

This allows handling a situation in which resolver returns different results 