### PR TITLE
Integrate prettier with eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+### file include overrides
+# root configuration files (e.g. .eslintrc.js)
+!.*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,54 +1,28 @@
 module.exports = {
-	"env": {
-		"node": true,
-		"commonjs": true,
-		"es6": true,
-		"jquery": false,
-		"jest": true,
-		"jasmine": true
+	env: {
+		node: true,
+		commonjs: true,
+		es6: true,
+		jquery: false,
+		jest: true,
+		jasmine: true,
 	},
-	"extends": [
-		"eslint:recommended",
-		"plugin:security/recommended"
-	],
-	"parserOptions": {
-		"sourceType": "module",
-		"ecmaVersion": 2017,
-		"ecmaFeatures": {
-			"experimentalObjectRestSpread": true
-		}
+	extends: ["eslint:recommended", "plugin:security/recommended", "plugin:prettier/recommended"],
+	parserOptions: {
+		sourceType: "module",
+		ecmaVersion: 2017,
+		ecmaFeatures: {
+			experimentalObjectRestSpread: true,
+		},
 	},
-	"plugins": [
-		"node",
-		"promise",
-		"security"
-	],
-	"rules": {
-		"indent": [
-			"warn",
-			"tab",
-			{ SwitchCase: 1 }
-		],
-		"quotes": [
-			"warn",
-			"double"
-		],
-		"semi": [
-			"error",
-			"always"
-		],
-		"no-var": [
-			"error"
-		],
-		"no-console": [
-			"error"
-		],
-		"no-unused-vars": [
-			"warn"
-		],
-		"no-trailing-spaces": [
-			"error"
-		],
+	plugins: ["node", "promise", "security"],
+	rules: {
+		quotes: ["warn", "double"],
+		semi: ["error", "always"],
+		"no-var": ["error"],
+		"no-console": ["error"],
+		"no-unused-vars": ["warn"],
+		"no-trailing-spaces": ["error"],
 		"no-alert": 0,
 		"no-shadow": 0,
 		"security/detect-object-injection": ["off"],
@@ -59,14 +33,11 @@ module.exports = {
 		"space-before-function-paren": [
 			"warn",
 			{
-				"anonymous": "never",
-				"named": "never",
-				"asyncArrow": "always"
-			}
+				anonymous: "never",
+				named: "never",
+				asyncArrow: "always",
+			},
 		],
-		"object-curly-spacing": [
-			"warn",
-			"always"
-		]
-	}
+		"object-curly-spacing": ["warn", "always"],
+	},
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+	useTabs: true,
+	printWidth: 100,
+	tabWidth: 2,
+	trailingComma: "all",
+	bracketSpacing: true,
+	semi: true,
+};

--- a/examples/full/index.js
+++ b/examples/full/index.js
@@ -6,7 +6,9 @@ const { ServiceBroker } = require("moleculer");
 const ApiGateway = require("moleculer-web");
 const { ApolloService } = require("../../index");
 
-const broker = new ServiceBroker({ logLevel: process.env.LOGLEVEL || "info"/*, transporter: "NATS"*/ });
+const broker = new ServiceBroker({
+	logLevel: process.env.LOGLEVEL || "info" /*, transporter: "NATS"*/,
+});
 
 broker.createService({
 	name: "api",
@@ -17,7 +19,6 @@ broker.createService({
 
 		// GraphQL Apollo Server
 		ApolloService({
-
 			// Global GraphQL typeDefs
 			typeDefs: `
 				scalar Date
@@ -34,11 +35,12 @@ broker.createService({
 						return value.toISOString().split("T")[0]; // value sent to the client
 					},
 					__parseLiteral(ast) {
-						if (ast.kind === Kind.INT)
+						if (ast.kind === Kind.INT) {
 							return parseInt(ast.value, 10); // ast value is always in string format
+						}
 
 						return null;
-					}
+					},
 				},
 				Timestamp: {
 					__parseValue(value) {
@@ -48,20 +50,20 @@ broker.createService({
 						return value.toISOString(); // value sent to the client
 					},
 					__parseLiteral(ast) {
-						if (ast.kind === Kind.INT)
+						if (ast.kind === Kind.INT) {
 							return parseInt(ast.value, 10); // ast value is always in string format
+						}
 
 						return null;
-					}
+					},
 				},
-
 			},
 
 			// API Gateway route options
 			routeOptions: {
 				path: "/graphql",
 				cors: true,
-				mappingPolicy: "restrict"
+				mappingPolicy: "restrict",
 			},
 
 			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
@@ -69,27 +71,26 @@ broker.createService({
 				tracing: false,
 
 				engine: {
-					apiKey: process.env.APOLLO_ENGINE_KEY
-				}
-			}
-		})
+					apiKey: process.env.APOLLO_ENGINE_KEY,
+				},
+			},
+		}),
 	],
 
 	events: {
 		"graphql.schema.updated"({ schema }) {
 			fs.writeFileSync(__dirname + "/generated-schema.gql", schema, "utf8");
 			this.logger.info("Generated GraphQL schema:\n\n" + schema);
-		}
-	}
+		},
+	},
 });
 
 broker.loadServices(__dirname);
 
-broker.start()
-	.then(async () => {
-		broker.repl();
+broker.start().then(async () => {
+	broker.repl();
 
-		broker.logger.info("----------------------------------------------------------");
-		broker.logger.info("Open the http://localhost:3000/graphql URL in your browser");
-		broker.logger.info("----------------------------------------------------------");
-	});
+	broker.logger.info("----------------------------------------------------------");
+	broker.logger.info("Open the http://localhost:3000/graphql URL in your browser");
+	broker.logger.info("----------------------------------------------------------");
+});

--- a/examples/full/posts.service.js
+++ b/examples/full/posts.service.js
@@ -1,14 +1,49 @@
 "use strict";
 
 const _ = require("lodash");
-const { MoleculerClientError } 	= require("moleculer").Errors;
+const { MoleculerClientError } = require("moleculer").Errors;
 
 const posts = [
-	{ id: 1, title: "First post", author: 3, votes: 2, voters: [2,5], createdAt: new Date("2018-08-23T08:10:25") },
-	{ id: 2, title: "Second post", author: 1, votes: 0, voters: [], createdAt:new Date("2018-11-23T12:59:30")  },
-	{ id: 3, title: "Third post", author: 2, votes: 1, voters: [5], createdAt:new Date("2018-02-23T22:24:28")  },
-	{ id: 4, title: "4th post", author: 3, votes: 3, voters: [4,1,2], createdAt: new Date("2018-10-23T10:33:00") },
-	{ id: 5, title: "5th post", author: 5, votes: 1, voters: [4], createdAt: new Date("2018-11-24T21:15:30") },
+	{
+		id: 1,
+		title: "First post",
+		author: 3,
+		votes: 2,
+		voters: [2, 5],
+		createdAt: new Date("2018-08-23T08:10:25"),
+	},
+	{
+		id: 2,
+		title: "Second post",
+		author: 1,
+		votes: 0,
+		voters: [],
+		createdAt: new Date("2018-11-23T12:59:30"),
+	},
+	{
+		id: 3,
+		title: "Third post",
+		author: 2,
+		votes: 1,
+		voters: [5],
+		createdAt: new Date("2018-02-23T22:24:28"),
+	},
+	{
+		id: 4,
+		title: "4th post",
+		author: 3,
+		votes: 3,
+		voters: [4, 1, 2],
+		createdAt: new Date("2018-10-23T10:33:00"),
+	},
+	{
+		id: 5,
+		title: "5th post",
+		author: 5,
+		votes: 1,
+		voters: [4],
+		createdAt: new Date("2018-11-24T21:15:30"),
+	},
 ];
 
 module.exports = {
@@ -35,143 +70,155 @@ module.exports = {
 						action: "users.resolve",
 						dataLoader: process.env.DATALOADER === "true",
 						rootParams: {
-							"author": "id"
-						}
+							author: "id",
+						},
 					},
 					voters: {
 						action: "users.resolve",
 						dataLoader: process.env.DATALOADER === "true",
 						rootParams: {
-							"voters": "id"
-						}
+							voters: "id",
+						},
 					},
 					error: {
 						action: "posts.error",
-						nullIfError: true
-					}
-				}
-			}
-		}
+						nullIfError: true,
+					},
+				},
+			},
+		},
 	},
 	actions: {
 		find: {
 			//cache: true,
 			params: {
-				limit: { type: "number", optional: true }
+				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: "posts(limit: Int): [Post]"
+				query: "posts(limit: Int): [Post]",
 			},
 			handler(ctx) {
 				let result = _.cloneDeep(posts);
-				if (ctx.params.limit)
+				if (ctx.params.limit) {
 					result = posts.slice(0, ctx.params.limit);
-				else
+				} else {
 					result = posts;
+				}
 
 				return _.cloneDeep(result);
-			}
+			},
 		},
 
 		count: {
 			params: {
-				query: { type: "object", optional: true }
+				query: { type: "object", optional: true },
 			},
 			handler(ctx) {
-				if (!ctx.params.query)
+				if (!ctx.params.query) {
 					return posts.length;
+				}
 
 				return posts.filter(post => post.author == ctx.params.query.author).length;
-			}
+			},
 		},
 
 		findByUser: {
 			params: {
-				userID: "number"
+				userID: "number",
 			},
 			handler(ctx) {
 				return _.cloneDeep(posts.filter(post => post.author == ctx.params.userID));
-			}
+			},
 		},
 
 		upvote: {
 			params: {
 				id: "number",
-				userID: "number"
+				userID: "number",
 			},
 			graphql: {
-				mutation: "upvote(id: Int!, userID: Int!): Post"
+				mutation: "upvote(id: Int!, userID: Int!): Post",
 			},
 			async handler(ctx) {
 				const post = this.findByID(ctx.params.id);
-				if (!post)
+				if (!post) {
 					throw new MoleculerClientError("Post is not found");
+				}
 
 				const has = post.voters.find(voter => voter == ctx.params.userID);
-				if (has)
+				if (has) {
 					throw new MoleculerClientError("User has already voted this post");
+				}
 
 				post.voters.push(ctx.params.userID);
 				post.votes = post.voters.length;
 
-				await ctx.broadcast("graphql.publish", { tag: "VOTE", payload: { type: "up", userID: ctx.params.userID } });
+				await ctx.broadcast("graphql.publish", {
+					tag: "VOTE",
+					payload: { type: "up", userID: ctx.params.userID },
+				});
 
 				return _.cloneDeep(post);
-			}
+			},
 		},
 
 		downvote: {
 			params: {
 				id: "number",
-				userID: "number"
+				userID: "number",
 			},
 			graphql: {
-				mutation: "downvote(id: Int!, userID: Int!): Post"
+				mutation: "downvote(id: Int!, userID: Int!): Post",
 			},
 			async handler(ctx) {
 				const post = this.findByID(ctx.params.id);
-				if (!post)
+				if (!post) {
 					throw new MoleculerClientError("Post is not found");
+				}
 
 				const has = post.voters.find(voter => voter == ctx.params.userID);
-				if (!has)
+				if (!has) {
 					throw new MoleculerClientError("User has not voted this post yet");
+				}
 
 				post.voters = post.voters.filter(voter => voter != ctx.params.userID);
 				post.votes = post.voters.length;
 
-				await ctx.broadcast("graphql.publish", { tag: "VOTE", payload: { type: "down", userID: ctx.params.userID } });
+				await ctx.broadcast("graphql.publish", {
+					tag: "VOTE",
+					payload: { type: "down", userID: ctx.params.userID },
+				});
 
 				return _.cloneDeep(post);
-			}
+			},
 		},
 		vote: {
 			params: { payload: "object" },
 			graphql: {
 				subscription: "vote(userID: Int!): String!",
 				tags: ["VOTE"],
-				filter: "posts.vote.filter"
+				filter: "posts.vote.filter",
 			},
 			handler(ctx) {
 				return ctx.params.payload.type;
-			}
+			},
 		},
 		"vote.filter": {
 			params: { userID: "number", payload: "object" },
 			handler(ctx) {
 				return ctx.params.payload.userID === ctx.params.userID;
-			}
+			},
 		},
 		error: {
 			handler() {
 				throw new Error("Oh look an error !");
-			}
+			},
 		},
 	},
 
 	methods: {
 		findByID(id) {
 			return posts.find(post => post.id == id);
-		}
-	}
+		},
+	},
 };

--- a/examples/full/users.service.js
+++ b/examples/full/users.service.js
@@ -42,52 +42,50 @@ module.exports = {
 					posts: {
 						action: "posts.findByUser",
 						rootParams: {
-							"id": "userID"
-						}
+							id: "userID",
+						},
 					},
 					postCount: {
 						// Call the "posts.count" action
 						action: "posts.count",
 						// Get `id` value from `root` and put it into `ctx.params.query.author`
 						rootParams: {
-							"id": "query.author"
-						}
-					}
+							id: "query.author",
+						},
+					},
 				},
 				UserType: {
 					ADMIN: "1",
 					PUBLISHER: "2",
-					READER: "3"
-				}
-			}
-		}
+					READER: "3",
+				},
+			},
+		},
 	},
 	actions: {
 		find: {
 			//cache: true,
 			params: {
-				limit: { type: "number", optional: true }
+				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: "users(limit: Int): [User]"
+				query: "users(limit: Int): [User]",
 			},
 			handler(ctx) {
 				let result = _.cloneDeep(users);
-				if (ctx.params.limit)
+				if (ctx.params.limit) {
 					result = users.slice(0, ctx.params.limit);
-				else
+				} else {
 					result = users;
+				}
 
 				return _.cloneDeep(result);
-			}
+			},
 		},
 
 		resolve: {
 			params: {
-				id: [
-					{ type: "number" },
-					{ type: "array", items: "number" }
-				]
+				id: [{ type: "number" }, { type: "array", items: "number" }],
 			},
 			handler(ctx) {
 				this.logger.debug("resolve action called.", { params: ctx.params });
@@ -96,13 +94,13 @@ module.exports = {
 				} else {
 					return _.cloneDeep(this.findByID(ctx.params.id));
 				}
-			}
-		}
+			},
+		},
 	},
 
 	methods: {
 		findByID(id) {
 			return users.find(user => user.id == id);
-		}
-	}
+		},
+	},
 };

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
-let { ServiceBroker } 	= require("moleculer");
+let { ServiceBroker } = require("moleculer");
 
-const ApiGateway 	= require("moleculer-web");
+const ApiGateway = require("moleculer-web");
 const { ApolloService } = require("../../index");
 
 const broker = new ServiceBroker({ logLevel: "info", hotReload: true });
@@ -16,24 +16,23 @@ broker.createService({
 
 		// GraphQL Apollo Server
 		ApolloService({
-
 			// API Gateway route options
 			routeOptions: {
 				path: "/graphql",
 				cors: true,
-				mappingPolicy: "restrict"
+				mappingPolicy: "restrict",
 			},
 
 			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
-			serverOptions: {}
-		})
+			serverOptions: {},
+		}),
 	],
 
 	events: {
 		"graphql.schema.updated"({ schema }) {
 			this.logger.info("Generated GraphQL schema:\n\n" + schema);
-		}
-	}
+		},
+	},
 });
 
 broker.createService({
@@ -42,50 +41,50 @@ broker.createService({
 	actions: {
 		hello: {
 			graphql: {
-				query: "hello: String!"
+				query: "hello: String!",
 			},
 			handler() {
 				return "Hello Moleculer!";
-			}
+			},
 		},
 		welcome: {
 			graphql: {
-				mutation: "welcome(name: String!): String!"
+				mutation: "welcome(name: String!): String!",
 			},
 			handler(ctx) {
 				return `Hello ${ctx.params.name}`;
-			}
+			},
 		},
 		update: {
 			graphql: {
 				subscription: "update: String!",
-				tags: ["TEST"]
+				tags: ["TEST"],
 			},
 			handler(ctx) {
 				return ctx.params.payload;
-			}
-		}
-	}
+			},
+		},
+	},
 });
 
-broker.start()
-	.then(async () => {
-		broker.repl();
+broker.start().then(async () => {
+	broker.repl();
 
-		const res = await broker.call("api.graphql", {
-			query: "query { hello }"
-		});
-
-		let counter = 1;
-		setInterval(async () => broker.broadcast("graphql.publish", { tag: "TEST", payload: `test ${counter++}` }), 5000);
-
-		if (res.errors && res.errors.length > 0)
-			return res.errors.forEach(broker.logger.error);
-
-		broker.logger.info(res.data);
-
-		broker.logger.info("----------------------------------------------------------");
-		broker.logger.info("Open the http://localhost:3000/graphql URL in your browser");
-		broker.logger.info("----------------------------------------------------------");
-
+	const res = await broker.call("api.graphql", {
+		query: "query { hello }",
 	});
+
+	let counter = 1;
+	setInterval(
+		async () => broker.broadcast("graphql.publish", { tag: "TEST", payload: `test ${counter++}` }),
+		5000,
+	);
+
+	if (res.errors && res.errors.length > 0) return res.errors.forEach(broker.logger.error);
+
+	broker.logger.info(res.data);
+
+	broker.logger.info("----------------------------------------------------------");
+	broker.logger.info("Open the http://localhost:3000/graphql URL in your browser");
+	broker.logger.info("----------------------------------------------------------");
+});

--- a/index.js
+++ b/index.js
@@ -39,5 +39,5 @@ module.exports = {
 	ApolloServer,
 
 	// Apollo Moleculer Service
-	ApolloService
+	ApolloService,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2443,6 +2443,23 @@
         "text-table": "^0.2.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-es": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.4.0.tgz",
@@ -2473,6 +2490,15 @@
           "integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {
@@ -2820,6 +2846,12 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2988,8 +3020,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3010,14 +3041,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3032,20 +3061,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3162,8 +3188,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3175,7 +3200,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3190,7 +3214,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3198,14 +3221,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3224,7 +3245,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3305,8 +3325,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3318,7 +3337,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3404,8 +3422,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3441,7 +3458,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3461,7 +3477,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3505,14 +3520,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6614,6 +6627,21 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "benchmarkify": "2.1.1",
     "coveralls": "3.0.2",
     "eslint": "5.13.0",
+    "eslint-config-prettier": "4.1.0",
     "eslint-plugin-node": "8.0.1",
+    "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-promise": "4.0.1",
     "eslint-plugin-security": "1.4.0",
     "graphql": "14.1.1",
@@ -43,7 +45,8 @@
     "moleculer-repl": "0.5.5",
     "moleculer-web": "0.9.0-beta1",
     "nodemon": "1.18.9",
-    "npm-check": "5.9.0"
+    "npm-check": "5.9.0",
+    "prettier": "1.16.4"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -10,15 +10,15 @@ function send(req, res, statusCode, data, responseType = "application/json") {
 	res.statusCode = statusCode;
 
 	const ctx = res.$ctx;
-	if (!ctx.meta.$responseType)
+	if (!ctx.meta.$responseType) {
 		ctx.meta.$responseType = responseType;
+	}
 
 	const service = res.$service;
 	service.sendResponse(req, res, data);
 }
 
 class ApolloServer extends ApolloServerBase {
-
 	// Extract Apollo Server options from the request.
 	createGraphQLServerOptions(req, res) {
 		return super.graphQLServerOptions({ req, res });
@@ -26,7 +26,7 @@ class ApolloServer extends ApolloServerBase {
 
 	// Prepares and returns an async function that can be used to handle
 	// GraphQL requests.
-	createHandler({ path, disableHealthCheck, onHealthCheck, } = {}) {
+	createHandler({ path, disableHealthCheck, onHealthCheck } = {}) {
 		const promiseWillStart = this.willStart();
 		return async (req, res) => {
 			this.graphqlPath = path || "/graphql";
@@ -52,10 +52,17 @@ class ApolloServer extends ApolloServerBase {
 			// incoming GraphQL requests.
 			if (this.playgroundOptions && req.method === "GET") {
 				const { mediaTypes } = accept.parseAll(req.headers);
-				const prefersHTML = mediaTypes.find((x) => x === "text/html" || x === "application/json") === "text/html";
+				const prefersHTML =
+					mediaTypes.find(x => x === "text/html" || x === "application/json") === "text/html";
 
 				if (prefersHTML) {
-					const middlewareOptions = Object.assign({ endpoint: this.graphqlPath, subscriptionEndpoint: this.subscriptionsPath }, this.playgroundOptions);
+					const middlewareOptions = Object.assign(
+						{
+							endpoint: this.graphqlPath,
+							subscriptionEndpoint: this.subscriptionsPath,
+						},
+						this.playgroundOptions,
+					);
 					return send(req, res, 200, renderPlaygroundPage(middlewareOptions), "text/html");
 				}
 			}
@@ -64,7 +71,6 @@ class ApolloServer extends ApolloServerBase {
 			const graphqlHandler = moleculerApollo(() => this.createGraphQLServerOptions(req, res));
 			const responseData = await graphqlHandler(req, res);
 			send(req, res, 200, responseData);
-
 		};
 	}
 

--- a/src/moleculerApollo.js
+++ b/src/moleculerApollo.js
@@ -14,24 +14,22 @@ module.exports = function graphqlMoleculer(options) {
 	}
 
 	if (arguments.length > 1) {
-		throw new Error(
-			`Apollo Server expects exactly one argument, got ${arguments.length}`,
-		);
+		throw new Error(`Apollo Server expects exactly one argument, got ${arguments.length}`);
 	}
 
 	return async function graphqlHandler(req, res) {
 		let query;
 		try {
-			if (req.method === "POST")
+			if (req.method === "POST") {
 				query = req.filePayload || req.body;
-			else
+			} else {
 				query = url.parse(req.url, true).query;
+			}
 		} catch (error) {
 			// Do nothing; `query` stays `undefined`
 		}
 
 		try {
-
 			const { graphqlResponse, responseInit } = await runHttpQuery([req, res], {
 				method: req.method,
 				options,
@@ -42,7 +40,6 @@ module.exports = function graphqlMoleculer(options) {
 			setHeaders(res, responseInit.headers);
 
 			return graphqlResponse;
-
 		} catch (error) {
 			if ("HttpQueryError" === error.name && error.headers) {
 				setHeaders(res, error.headers);


### PR DESCRIPTION
This PR enables support for Prettier code formatter using the eslint integration.

I've run through a few simulations under different settings.  This PR utilizes a max-width of 100 characters with a tab size of 2.  The tab size of 2 is different than the preferred size for the repo, but since the repo uses tabs instead of spaces, this is really just a prettier optimization strategy choice.  Effectively, prettier will count an indent as 2 spaces instead of 4 when calculating its break points which makes the usage of indentation less important in the total width calculation than it would be at a break point of 4.  In trial runs of different settings, this produced what appeared (to me) to be the most optimal formatting.  Trying different settings is very easy (and I have several branches in my fork doing so) so if we want to see something else we can do so.

All existing code has been run through `eslint --fix` so prettier has reformatted the repo entirely and any outstanding eslint issues have also been addressed.

Resolves #25 