### PR TITLE
Allow arrays for all graphql definitions

### DIFF
--- a/examples/full/index.js
+++ b/examples/full/index.js
@@ -20,10 +20,7 @@ broker.createService({
 		// GraphQL Apollo Server
 		ApolloService({
 			// Global GraphQL typeDefs
-			typeDefs: `
-				scalar Date
-				scalar Timestamp
-			`,
+			typeDefs: ["scalar Date", "scalar Timestamp"],
 
 			// Global resolvers
 			resolvers: {

--- a/examples/full/posts.service.js
+++ b/examples/full/posts.service.js
@@ -95,7 +95,11 @@ module.exports = {
 				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: "posts(limit: Int): [Post]",
+				query: `
+					posts(
+						limit: Int
+					): [Post]
+				`,
 			},
 			handler(ctx) {
 				let result = _.cloneDeep(posts);
@@ -137,7 +141,12 @@ module.exports = {
 				userID: "number",
 			},
 			graphql: {
-				mutation: "upvote(id: Int!, userID: Int!): Post",
+				mutation: `
+					upvote(
+						id: Int!
+						userID: Int!
+					): Post
+				`,
 			},
 			async handler(ctx) {
 				const post = this.findByID(ctx.params.id);
@@ -168,7 +177,12 @@ module.exports = {
 				userID: "number",
 			},
 			graphql: {
-				mutation: "downvote(id: Int!, userID: Int!): Post",
+				mutation: `
+					downvote(
+						id: Int!
+						userID: Int!
+					): Post
+				`,
 			},
 			async handler(ctx) {
 				const post = this.findByID(ctx.params.id);
@@ -195,7 +209,11 @@ module.exports = {
 		vote: {
 			params: { payload: "object" },
 			graphql: {
-				subscription: "vote(userID: Int!): String!",
+				subscription: `
+					vote(
+						userID: Int!
+					): String!
+				`,
 				tags: ["VOTE"],
 				filter: "posts.vote.filter",
 			},

--- a/examples/full/users.service.js
+++ b/examples/full/users.service.js
@@ -69,7 +69,11 @@ module.exports = {
 				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: "users(limit: Int): [User]",
+				query: `
+					users(
+						limit: Int
+					): [User]
+				`,
 			},
 			handler(ctx) {
 				let result = _.cloneDeep(users);

--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -49,7 +49,11 @@ broker.createService({
 		},
 		welcome: {
 			graphql: {
-				mutation: "welcome(name: String!): String!",
+				mutation: `
+					welcome(
+						name: String!
+					): String!
+				`,
 			},
 			handler(ctx) {
 				return `Hello ${ctx.params.name}`;


### PR DESCRIPTION
This PR introduces a (mostly) backwards-compatible change to allow for the GraphQL definitions to be provided as `string` or `string[]`.  If arrays are provided, the contents will end up concatenated into a final string which is similar to how the definitions are concatenated for multiple service instances.  This should make it easier to define the definitions in separately imported files as the constant string values can be added as array items rather than manually concatenating them (such as with templated strings).
This should have no impact to existing use cases (except one, noted below) as the existing string structure is still supported.
### Affected properties
#### Mixin Option Properties
* `typeDefs`
#### Global Service Properties
* `query`
* `mutation`
* `subscription`
* `type`
* `interface`
* `union`
* `enum`
* `input`
#### Service Action Properties
* `query`
* `mutation`
* `subscription`
* `type`
* `interface`
* `union`
* `enum`
* `input`

The lone breaking change in this PR is to revert the mechanism by which multiple mutations were allowed to be bound to a single action, introduced in #21.  Instead of specifying multiple mutation definitions using a newline, multiple mutation definitions can be defined using an array.  That change will allow mutation strings to be broken across lines using templated string syntax, similar to queries and subscriptions.

Resolves #27.