### PR TITLE
Create moleculer compatible gql formatter

### DIFF
--- a/examples/full/posts.service.js
+++ b/examples/full/posts.service.js
@@ -2,6 +2,7 @@
 
 const _ = require("lodash");
 const { MoleculerClientError } = require("moleculer").Errors;
+const { moleculerGql: gql } = require("../../index");
 
 const posts = [
 	{
@@ -50,16 +51,16 @@ module.exports = {
 	name: "posts",
 	settings: {
 		graphql: {
-			type: `
+			type: gql`
 				"""
 				This type describes a post entity.
 				"""
 				type Post {
-					id: Int!,
-					title: String!,
-					author: User!,
-					votes: Int!,
-					voters: [User],
+					id: Int!
+					title: String!
+					author: User!
+					votes: Int!
+					voters: [User]
 					createdAt: Timestamp
 					error: String
 				}
@@ -95,10 +96,10 @@ module.exports = {
 				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: `
-					posts(
-						limit: Int
-					): [Post]
+				query: gql`
+					type Query {
+						posts(limit: Int): [Post]
+					}
 				`,
 			},
 			handler(ctx) {
@@ -141,11 +142,10 @@ module.exports = {
 				userID: "number",
 			},
 			graphql: {
-				mutation: `
-					upvote(
-						id: Int!
-						userID: Int!
-					): Post
+				mutation: gql`
+					type Mutation {
+						upvote(id: Int!, userID: Int!): Post
+					}
 				`,
 			},
 			async handler(ctx) {
@@ -177,11 +177,10 @@ module.exports = {
 				userID: "number",
 			},
 			graphql: {
-				mutation: `
-					downvote(
-						id: Int!
-						userID: Int!
-					): Post
+				mutation: gql`
+					type Mutation {
+						downvote(id: Int!, userID: Int!): Post
+					}
 				`,
 			},
 			async handler(ctx) {
@@ -209,10 +208,10 @@ module.exports = {
 		vote: {
 			params: { payload: "object" },
 			graphql: {
-				subscription: `
-					vote(
-						userID: Int!
-					): String!
+				subscription: gql`
+					type Subscription {
+						vote(userID: Int!): String!
+					}
 				`,
 				tags: ["VOTE"],
 				filter: "posts.vote.filter",

--- a/examples/full/users.service.js
+++ b/examples/full/users.service.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+const { moleculerGql: gql } = require("../../index");
 
 const users = [
 	{ id: 1, name: "Genaro Krueger", birthday: new Date("1975-12-17"), type: "1" },
@@ -14,7 +15,7 @@ module.exports = {
 	name: "users",
 	settings: {
 		graphql: {
-			type: `
+			type: gql`
 				"""
 				This type describes a user entity.
 				"""
@@ -23,11 +24,11 @@ module.exports = {
 					name: String!
 					birthday: Date
 					posts(limit: Int): [Post]
-					postCount: Int,
+					postCount: Int
 					type: UserType
 				}
 			`,
-			enum: `
+			enum: gql`
 				"""
 				Enumerations for user types
 				"""
@@ -69,10 +70,10 @@ module.exports = {
 				limit: { type: "number", optional: true },
 			},
 			graphql: {
-				query: `
-					users(
-						limit: Int
-					): [User]
+				query: gql`
+					type Query {
+						users(limit: Int): [User]
+					}
 				`,
 			},
 			handler(ctx) {

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@
 const core = require("apollo-server-core");
 const { ApolloServer } = require("./src/ApolloServer");
 const ApolloService = require("./src/service");
+const gql = require("./src/gql");
 
 module.exports = {
 	// Core
@@ -40,4 +41,7 @@ module.exports = {
 
 	// Apollo Moleculer Service
 	ApolloService,
+
+	// Moleculer gql formatter
+	moleculerGql: gql,
 };

--- a/src/gql.js
+++ b/src/gql.js
@@ -1,0 +1,22 @@
+const { zip } = require("lodash");
+
+/**
+ * @function gql Format graphql strings for usage in moleculer-apollo-server
+ * @param {TemplateStringsArray} typeString - Template string array for formatting
+ * @param  {...string} placeholders - Placeholder expressions
+ */
+const gql = (typeString, ...placeholders) => {
+	// combine template string array and placeholders into a single string
+	const zipped = zip(typeString, placeholders);
+	const combinedString = zipped.reduce(
+		(prev, [next, placeholder]) => `${prev}${next}${placeholder || ""}`,
+		"",
+	);
+	const re = /type\s+(Query|Mutation|Subscription)\s+{(.*?)}/s;
+
+	const result = re.exec(combinedString);
+	// eliminate Query/Mutation/Subscription wrapper if present as moleculer-apollo-server will stitch them together
+	return Array.isArray(result) ? result[2] : combinedString;
+};
+
+module.exports = gql;


### PR DESCRIPTION
When using GraphQL-aware tooling, IDEs can syntax highlight and autoformat GraphQL strings.  For instance, with vscode, if using the Apollo GraphQL extension, templated strings formatted using graphql-tag (`gql`) will be syntax highlighted and automatically formatted using prettier.  However, since moleculer-apollo-server's API dictates that types, queries, mutations, etc. are strings, `gql` cannot be used to format those strings since its output is an object.

This PR creates a dummy implementation of `gql` which serves to trick this tooling into syntax highlighting and automatically formatting the strings.  Instead of actually converting the string into an object, it will instead do the following:
If a string is formatted as:
```
type Query {
  ...stuff...
}
```
it will return `...stuff...`.  This behavior is the same for `type Mutation` and `type Subscription`.  All other strings are left unmutated.  The removal of the type wrappers is required since moleculer-apollo-server will rewrap the queries, mutations, and subscriptions in a `Type` structure before passing to apollo.

This effectively allows type definitions to remain the same except for specifying `gql` prior to the template string. For queries, mutations, and subscriptions to be useful, wrapping them in a dummy `Type Query {}` structure will gain the benefits of syntax highlighting and formatting but ultimately provide data to moleculer-apollo-server in the expected format.

Examples have been updated to take advantage of the highlighting and formatting.  It should be noted that there is no requirement to wrap queries, mutations, and subscriptions nor to use the `gql` formatter.  It's merely a way to get the IDEs to look nicer.

Since the "real" `gql` is already being exported, I've exported this as `moleculerGql`, but it will need to be aliased as `gql` in order to gain any benefits from it.