### PR TITLE
Allow schemaDirectives

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -153,6 +153,7 @@ module.exports = function(mixinOptions) {
 				try {
 					let typeDefs = [];
 					let resolvers = {};
+					let schemaDirectives = null;
 
 					if (mixinOptions.typeDefs) {
 						typeDefs = typeDefs.concat(mixinOptions.typeDefs);
@@ -160,6 +161,10 @@ module.exports = function(mixinOptions) {
 
 					if (mixinOptions.resolvers) {
 						resolvers = _.cloneDeep(mixinOptions.resolvers);
+					}
+
+					if (mixinOptions.schemaDirectives) {
+						schemaDirectives = _.cloneDeep(mixinOptions.schemaDirectives);
 					}
 
 					let queries = [];
@@ -367,7 +372,7 @@ module.exports = function(mixinOptions) {
 						typeDefs.push(str);
 					}
 
-					return makeExecutableSchema({ typeDefs, resolvers });
+					return makeExecutableSchema({ typeDefs, resolvers, schemaDirectives });
 				} catch (err) {
 					throw new MoleculerServerError(
 						"Unable to compile GraphQL schema",


### PR DESCRIPTION
[Schema directives](https://www.apollographql.com/docs/graphql-tools/schema-directives) are a feature of Apollo Server which allow for a large number of potential use cases.  To quote the referenced link:
>The possible applications of directive syntax are numerous: enforcing access permissions, formatting date strings, auto-generating resolver functions for a particular backend API, marking strings for internationalization, synthesizing globally unique object identifiers, specifying caching behavior, skipping or including or deprecating fields, and just about anything else you can imagine.

An immediate use case for `moleculer-apollo-server` is that of enforcing access restrictions.  Since the Apollo server is only served up from a single route, traditional route based authorization controls are not possible.  With directives, API consumers can create their own custom directives to enforce authorization in any way they would like on types, queries, mutations, fields, etc.

This PR adds a new `schemaDirectives` option to the mixin parameters.  If specified, it will be passed to `makeExecutableSchema` and get added to the SDL generated by that function.