### PR TITLE
Fix undefined meta

### DIFF
--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -10,6 +10,7 @@ function send(req, res, statusCode, data, responseType = "application/json") {
 	res.statusCode = statusCode;
 
 	const ctx = res.$ctx;
+	ctx.meta = ctx.meta || {}
 	if (!ctx.meta.$responseType) {
 		ctx.meta.$responseType = responseType;
 	}


### PR DESCRIPTION
I don't know if this is the best way to fix this.

I have this error : 
![image](https://user-images.githubusercontent.com/1301995/58763732-3939fe00-855f-11e9-8de8-f301ff03c19e.png)

After a little search this is the "Upgrade request" for websocket, who is empty of query/mutation and end with no meta object. (I don't know why meta is undefined)