### PR TITLE
Merge params with rootParams when using dataloader

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -464,16 +464,22 @@ module.exports = function(mixinOptions) {
 						const typeLoaders = Object.values(resolvers).reduce((resolverAccum, type) => {
 							const resolverLoaders = Object.values(type).reduce((fieldAccum, resolver) => {
 								if (_.isPlainObject(resolver)) {
-									const { action, dataLoader = false, rootParams = {} } = resolver;
+									const { action, dataLoader = false, params = {}, rootParams = {} } = resolver;
 									const actionParam = Object.values(rootParams)[0]; // use the first root parameter
 									if (dataLoader && actionParam) {
 										const resolverActionName = this.getResolverActionName(serviceName, action);
 										if (fieldAccum[resolverActionName] == null) {
 											// create a new DataLoader instance
 											fieldAccum[resolverActionName] = new DataLoader(keys =>
-												req.$ctx.call(resolverActionName, {
-													[actionParam]: keys,
-												}),
+												req.$ctx.call(
+													resolverActionName,
+													_.defaultsDeep(
+														{
+															[actionParam]: keys,
+														},
+														params,
+													),
+												),
 											);
 										}
 									}


### PR DESCRIPTION
Currently when making use of `DataLoader` for child resolution, the only parameters that are being passed to the action are those specified by `rootParams`.  I've found a use case where `params` was needed as well and it is viable to access them in the `DataLoader` batch function because they are static values and not contextually dependent.  This PR merges any provided `params` in to the call to the action.

Note: I don't think there is a use case where field `args` can actually be utilized with `DataLoader` for child resolution.  The scope of `args` is during resolution and `loader.load()` expects only a single value to be specified.