### PR TITLE
update createActionResolver to use lodash get

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -93,7 +93,7 @@ module.exports = function(mixinOptions) {
 					try {
 						if (dataLoader) {
 							const dataLoaderKey = rootKeys[0]; // use the first root key
-							const rootValue = root && root[dataLoaderKey];
+							const rootValue = root && _.get(root, dataLoaderKey);
 							if (rootValue == null) {
 								return null;
 							}


### PR DESCRIPTION
This PR updates the `createActionResolver` function to make the dataloader implementation consistent with the non-dataloader implementation by allowing for `lodash` keypath notation to work when accessing data from the root. 