### PR TITLE
Add one option to discover only local graphql actions

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -179,12 +179,13 @@ module.exports = function(mixinOptions) {
 					const processedServices = new Set();
 
 					services.forEach(service => {
-						if (service.settings.graphql) {
-							const serviceName = this.getServiceName(service);
+						const serviceName = this.getServiceName(service);
 
-							// Skip multiple instances of services
-							if (processedServices.has(serviceName)) return;
-							processedServices.add(serviceName);
+						// Skip multiple instances of services
+						if (processedServices.has(serviceName)) return;
+						processedServices.add(serviceName);
+
+						if (service.settings.graphql) {
 
 							// --- COMPILE SERVICE-LEVEL DEFINITIONS ---
 							if (_.isObject(service.settings.graphql)) {


### PR DESCRIPTION
This little option enable the ability to launch multiple instance of the gateway (For load balancing, fault tolerance and other HA beautiful mechanisms) .

Take the case when you launch 4 instances of your api gateway
If ```onlyLocal: false``` it will discover remote services, duplicate schema will happend and you will have error like this :
![image](https://user-images.githubusercontent.com/1301995/60385766-5e059080-9a8d-11e9-96cc-1a89c474105f.png)

But if you have ```onlyLocal: true``` your 4 instances of your api gateway will discover only their locales actions, no duplicate will happens and your little k8s cluster with his multiple pods will be happy :smiley: 