### PR TITLE
Relocate setting of subscription event

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -32,6 +32,11 @@ module.exports = function(mixinOptions) {
 			"$services.changed"() {
 				this.invalidateGraphQLSchema();
 			},
+			[mixinOptions.subscriptionEventName](event) {
+				if (this.pubsub) {
+					this.pubsub.publish(event.tag, event.payload);
+				}
+			},
 		},
 
 		methods: {
@@ -186,7 +191,6 @@ module.exports = function(mixinOptions) {
 						processedServices.add(serviceName);
 
 						if (service.settings.graphql) {
-
 							// --- COMPILE SERVICE-LEVEL DEFINITIONS ---
 							if (_.isObject(service.settings.graphql)) {
 								const globalDef = service.settings.graphql;
@@ -553,10 +557,6 @@ module.exports = function(mixinOptions) {
 			},
 		};
 	}
-	serviceSchema.events = {
-		[mixinOptions.subscriptionEventName](event) {
-			this.pubsub.publish(event.tag, event.payload);
-		},
-	};
+
 	return serviceSchema;
 };


### PR DESCRIPTION
This PR resolves #37.

The `subscriptionEventName` mixin option was overwriting the `serviceSchema.events` property, thus eliminating the `$services.changed` event.  This prevented the GraphQL schema from being invalidated and regenerated when a service change event fired.  To prevent this, I've relocated the setting of the subscription event to the same assignation as the `$services.changed` event so one will not overwrite the other.

Additionally, I discovered that there was another unrelated issue with the subscription event.  If the GraphQL schema had not been generated, `this.pubsub` was undefined and an exception would be thrown if the event was fired.  I've added a conditional check to ensure that `this.pubsub` is assigned prior to calling the `publish` method on that object.