### PR TITLE
Fix max callstack in schema creation

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -404,9 +404,9 @@ module.exports = function(mixinOptions) {
 
 					this.logger.debug("Generated GraphQL schema:\n\n" + GraphQL.printSchema(schema));
 
-					this.apolloServer = new ApolloServer(
-						_.defaultsDeep(mixinOptions.serverOptions, {
-							schema,
+					this.apolloServer = new ApolloServer({
+						schema,
+						..._.defaultsDeep(mixinOptions.serverOptions, {
 							context: ({ req, connection }) => {
 								return req
 									? {
@@ -426,7 +426,7 @@ module.exports = function(mixinOptions) {
 								}),
 							},
 						}),
-					);
+					});
 
 					this.graphqlHandler = this.apolloServer.createHandler();
 					this.apolloServer.installSubscriptionHandlers(this.server);


### PR DESCRIPTION
I was getting some weird 'max callstack size' : 
![image](https://user-images.githubusercontent.com/1301995/61174960-ddc04e80-a5a7-11e9-9487-b399cd9891eb.png)
And after i little digging, i see the `defaultsDeep` with schema declaration inside.
But the `schema` is a pretty big object with lots of nested property (I have a medium/large schema).

First i change the `defaultDeep` with `defaults` because most of property are on the first depth level, and i see the `subscriptions` object (And maybe more in the future).
So i move the `schema` outside of the defaultDeep, i don't think you will set a custom schema declaration in your `serverOptions` (Correct me if i'm wrong ?)