### PR TITLE
Fix healthcheck + examples

### DIFF
--- a/examples/health/index.js
+++ b/examples/health/index.js
@@ -1,0 +1,109 @@
+"use strict";
+
+let { ServiceBroker } = require("moleculer");
+
+const ApiGateway = require("moleculer-web");
+const { ApolloService } = require("../../index");
+
+const brokerWithRandomHealthy = new ServiceBroker({
+	logLevel: "info",
+	hotReload: true,
+	namespace: "randomhealthy",
+});
+
+const brokerWithWrongSchema = new ServiceBroker({
+	logLevel: "info",
+	hotReload: true,
+	namespace: "wrongschema",
+});
+
+const greeterService = {
+	name: "greeter",
+
+	actions: {
+		hello: {
+			graphql: {
+				query: "hello: String!",
+			},
+			handler() {
+				return "Hello Moleculer!";
+			},
+		},
+	},
+};
+
+// ===================================
+// Random healthy
+// ===================================
+
+brokerWithRandomHealthy.createService({
+	name: "api",
+	settings: { port: 3000 },
+	mixins: [
+		// Gateway
+		ApiGateway,
+
+		// GraphQL Apollo Server
+		ApolloService({
+			// API Gateway route options
+			routeOptions: {
+				path: "/graphql",
+				cors: true,
+				mappingPolicy: "restrict",
+			},
+
+			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
+			serverOptions: {
+				async onHealthCheck() {
+					if (Math.random() >= 0.5) {
+						throw new Error("Database not connected");
+					}
+					return { database: true, storage: true };
+				},
+			},
+		}),
+	],
+});
+brokerWithRandomHealthy.createService(greeterService);
+
+// ===================================
+// Schema non healthy
+// ===================================
+
+brokerWithWrongSchema.createService({
+	name: "api",
+	settings: { port: 3001 },
+	mixins: [
+		// Gateway
+		ApiGateway,
+
+		// GraphQL Apollo Server
+		ApolloService({
+			typeDefs: "ThisIsSoWrongInMySchema",
+			// API Gateway route options
+			routeOptions: {
+				path: "/graphql",
+				cors: true,
+				mappingPolicy: "restrict",
+			},
+
+			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
+			serverOptions: {},
+		}),
+	],
+});
+brokerWithWrongSchema.createService(greeterService);
+
+// ===================================
+
+Promise.all([brokerWithRandomHealthy.start(), brokerWithWrongSchema.start()]).then(() => {
+	brokerWithWrongSchema.logger.info("API With wrong schema started ----------------------------");
+	brokerWithWrongSchema.logger.info("Open the http://localhost:3001/graphql URL in your browser");
+	brokerWithWrongSchema.logger.info("----------------------------------------------------------");
+
+	brokerWithRandomHealthy.logger.info("API With random health result (1/2) ----------------------");
+	brokerWithRandomHealthy.logger.info("Open the http://localhost:3000/graphql URL in your browser");
+	brokerWithRandomHealthy.logger.info("----------------------------------------------------------");
+
+	brokerWithWrongSchema.repl();
+});

--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -28,6 +28,7 @@ class ApolloServer extends ApolloServerBase {
 	// GraphQL requests.
 	createHandler({ path, disableHealthCheck, onHealthCheck } = {}) {
 		const promiseWillStart = this.willStart();
+
 		return async (req, res) => {
 			this.graphqlPath = path || "/graphql";
 
@@ -82,6 +83,17 @@ class ApolloServer extends ApolloServerBase {
 	// This integration supports subscriptions.
 	supportsSubscriptions() {
 		return true;
+	}
+
+	async handleHealthCheck({ req, res, onHealthCheck }) {
+		onHealthCheck = onHealthCheck || (() => undefined);
+		try {
+			const result = await onHealthCheck(req);
+			send(req, res, 200, { status: "pass", result }, "application/health+json");
+		} catch (error) {
+			const result = error instanceof Error ? error.toString() : error;
+			send(req, res, 503, { status: "fail", result }, "application/health+json");
+		}
 	}
 }
 exports.ApolloServer = ApolloServer;

--- a/src/service.js
+++ b/src/service.js
@@ -428,7 +428,7 @@ module.exports = function(mixinOptions) {
 						}),
 					);
 
-					this.graphqlHandler = this.apolloServer.createHandler();
+					this.graphqlHandler = this.apolloServer.createHandler(mixinOptions.serverOptions);
 					this.apolloServer.installSubscriptionHandlers(this.server);
 					this.graphqlSchema = schema;
 
@@ -517,6 +517,20 @@ module.exports = function(mixinOptions) {
 						} catch (err) {
 							this.sendError(req, res, err);
 						}
+					},
+					"/.well-known/apollo/server-health"(req, res) {
+						try {
+							this.prepareGraphQLSchema();
+						} catch (err) {
+							res.statusCode = 503;
+							return this.sendResponse(
+								req,
+								res,
+								{ status: "fail", schema: false },
+								{ responseType: "application/health+json" },
+							);
+						}
+						return this.graphqlHandler(req, res);
 					},
 				},
 


### PR DESCRIPTION
This add the missing handler/route for healthcheck, plus :

- Custom function for healthcheck (With `onHealthCheck` from ApolloServer options)
- Fail healthcheck in case of schema error
- Examples for healthcheck

Tell me if anything wrong/not done in your good practices :)