### PR TITLE
Add support for descriptions and comments in a gql declaration

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -252,7 +252,7 @@ module.exports = function(mixinOptions) {
 									if (!resolver["Query"]) resolver.Query = {};
 
 									_.castArray(def.query).forEach(query => {
-										const name = query.trim().split(/[(:]/g)[0];
+										const name = this.getFieldName(query);
 										queries.push(query);
 										resolver.Query[name] = this.createActionResolver(action.name);
 									});
@@ -262,7 +262,7 @@ module.exports = function(mixinOptions) {
 									if (!resolver["Mutation"]) resolver.Mutation = {};
 
 									_.castArray(def.mutation).forEach(mutation => {
-										const name = mutation.trim().split(/[(:]/g)[0];
+										const name = this.getFieldName(mutation);
 										mutations.push(mutation);
 										resolver.Mutation[name] = this.createActionResolver(action.name);
 									});
@@ -272,7 +272,7 @@ module.exports = function(mixinOptions) {
 									if (!resolver["Subscription"]) resolver.Subscription = {};
 
 									_.castArray(def.subscription).forEach(subscription => {
-										const name = subscription.trim().split(/[(:]/g)[0];
+										const name = this.getFieldName(subscription);
 										subscriptions.push(subscription);
 										resolver.Subscription[name] = this.createAsyncIteratorResolver(
 											action.name,
@@ -441,6 +441,20 @@ module.exports = function(mixinOptions) {
 					this.logger.error(err);
 					throw err;
 				}
+			},
+
+			/**
+			 * Return the field name in a GraphQL Mutation, Query, or Subscription declaration
+			 * @param {String} declaration - Mutation, Query, or Subscription declaration
+			 * @returns {String} Field name of declaration
+			 */
+			getFieldName(declaration) {
+				// Remove all multi-line/single-line descriptions and comments
+				const cleanedDeclaration = declaration
+					.replace(/"([\s\S]*?)"/g, "")
+					.replace(/^[\s]*?#.*\n?/gm, "")
+					.trim();
+				return cleanedDeclaration.split(/[(:]/g)[0];
 			},
 
 			/**


### PR DESCRIPTION
The PR adds support for single and multi-line descriptions and comments in GraphQL Mutation, Query, and Subscription declarations.

Before this change, adding a description or comment in the declaration before the field name would cause the GraphQL schema to fail to compile because an invalid field name would be parsed out. This field name would then be used to look up the query, mutation, or subscription to set a resolver.

Before parsing out the field name, all descriptions and comments are removed. This has no affect on what is sent to the ApolloServer so these descriptions will show up in the schema and docs.

With this change something like this is possible:

`
type Mutation {
	"""
	Allow a store manager to delete a line on an order
	"""
	# TODO - Add logging
	lineDeleteById(lineId: ID!): Line @auth(roles: [store_manager])
}
`
