### PR TITLE
Change editorconfig to support ide defined tab size for js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,4 @@ indent_size = 2
 
 [*.js]
 quote_type = "double"
+indent_size = unset

--- a/src/service.js
+++ b/src/service.js
@@ -510,8 +510,8 @@ module.exports = function(mixinOptions) {
 			createLoaders(req, services) {
 				return services.reduce((serviceAccum, service) => {
 					const serviceName = this.getServiceName(service);
-					if(!service.settings) {
-						service.settings = {}
+					if (!service.settings) {
+						service.settings = {};
 					}
 					const { graphql } = service.settings;
 					if (graphql && graphql.resolvers) {


### PR DESCRIPTION
Update the `.editorconfig` file to add an `unset` setting to the tab size for `.js` files.  This should have the effect of leaving tabs as the preferred index style, but allowing the IDE to define the size of the tabs.  This should let people choose their own view of the codebase.

I also fixed a lint issue in `service.js`.