### PR TITLE
Improved DataLoader

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,3 +28,4 @@ indent_size = 2
 
 [*.js]
 quote_type = "double"
+indent_size = unset

--- a/package-lock.json
+++ b/package-lock.json
@@ -2417,9 +2417,9 @@
       }
     },
     "dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
     },
     "debug": {
       "version": "4.1.1",
@@ -2640,7 +2640,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -7249,7 +7249,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
           "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
           "dev": true
         },
@@ -7334,7 +7334,7 @@
         },
         "inquirer": {
           "version": "0.12.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
@@ -7382,13 +7382,13 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
         "ora": {
           "version": "0.2.3",
-          "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
           "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
           "dev": true,
           "requires": {
@@ -7538,6 +7538,11 @@
           }
         }
       }
+    },
+    "object-hash": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.1.tgz",
+      "integrity": "sha512-HgcGMooY4JC2PBt9sdUdJ6PMzpin+YtY3r/7wg0uTifP+HJWW8rammseSEHuyt0UeShI183UGssCJqm1bJR7QA=="
     },
     "object-keys": {
       "version": "1.0.12",

--- a/package.json
+++ b/package.json
@@ -68,10 +68,11 @@
     "@apollographql/graphql-playground-html": "^1.6.24",
     "accept": "^3.1.3",
     "apollo-server-core": "^2.9.6",
-    "dataloader": "^1.4.0",
+    "dataloader": "^2.0.0",
     "graphql-subscriptions": "^1.1.0",
     "graphql-tools": "^4.0.5",
     "graphql-upload": "^8.1.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "object-hash": "^2.0.1"
   }
 }

--- a/src/service.js
+++ b/src/service.js
@@ -198,6 +198,7 @@ module.exports = function(mixinOptions) {
 			 * @param {string} actionName - Fully qualified action name to bind to dataloader
 			 * @param {Object.<string, any>} staticParams - Static parameters to use in dataloader
 			 * @param {Object.<string, any>} args - Arguments passed to GraphQL child resolver
+			 * @returns {string} Key to the dataloader instance
 			 */
 			getDataLoaderMapKey(actionName, staticParams, args) {
 				if (Object.keys(staticParams).length > 0 || Object.keys(args).length > 0) {
@@ -219,6 +220,7 @@ module.exports = function(mixinOptions) {
 			 * @param {string} batchedParamKey - Parameter key to use for loaded values
 			 * @param {Object} staticParams - Static parameters to use in dataloader
 			 * @param {Object} args - Arguments passed to GraphQL child resolver
+			 * @returns {DataLoader} Dataloader instance
 			 */
 			buildDataLoader(ctx, actionName, batchedParamKey, staticParams, args) {
 				const batchLoadFn = keys => {

--- a/src/service.js
+++ b/src/service.js
@@ -154,10 +154,11 @@ module.exports = function(mixinOptions) {
 							if (context.dataLoaders.has(dataLoaderMapKey)) {
 								dataLoader = context.dataLoaders.get(dataLoaderMapKey);
 							} else {
+								const batchedParamKey = rootParams[dataLoaderRootKey];
 								dataLoader = this.buildDataLoader(
 									context.ctx,
 									actionName,
-									dataLoaderRootKey,
+									batchedParamKey,
 									staticParams,
 									args
 								);
@@ -179,9 +180,10 @@ module.exports = function(mixinOptions) {
 									_.set(params, rootParams[key], _.get(root, key))
 								);
 							}
+
 							return await context.ctx.call(
 								actionName,
-								_.defaultsDeep(args, params, staticParams)
+								_.defaultsDeep({}, args, params, staticParams)
 							);
 						}
 					} catch (err) {
@@ -206,7 +208,7 @@ module.exports = function(mixinOptions) {
 			getDataLoaderMapKey(actionName, staticParams, args) {
 				if (Object.keys(staticParams).length > 0 || Object.keys(args).length > 0) {
 					// create a unique hash of the static params and the arguments to ensure a unique DataLoader instance
-					const actionParams = _.defaultsDeep(args, staticParams);
+					const actionParams = _.defaultsDeep({}, args, staticParams);
 					const paramsHash = hash(actionParams);
 					return `${actionName}:${paramsHash}`;
 				}
@@ -227,7 +229,7 @@ module.exports = function(mixinOptions) {
 			buildDataLoader(ctx, actionName, batchedParamKey, staticParams, args) {
 				const batchLoadFn = keys => {
 					const rootParams = { [batchedParamKey]: keys };
-					return ctx.call(actionName, _.defaultsDeep(args, rootParams, staticParams));
+					return ctx.call(actionName, _.defaultsDeep({}, args, rootParams, staticParams));
 				};
 
 				if (dataLoaderOptions.has(actionName)) {

--- a/src/service.js
+++ b/src/service.js
@@ -26,12 +26,6 @@ module.exports = function(mixinOptions) {
 		subscriptionEventName: "graphql.publish",
 	});
 
-	/**
-	 * DataLoader options
-	 * @type {Map<string, Object.<string, any>>} Action name key; value of options object to pass to DataLoader constructor
-	 */
-	const dataLoaderOptions = new Map();
-
 	const serviceSchema = {
 		events: {
 			"$services.changed"() {
@@ -232,9 +226,9 @@ module.exports = function(mixinOptions) {
 					return ctx.call(actionName, _.defaultsDeep({}, args, rootParams, staticParams));
 				};
 
-				if (dataLoaderOptions.has(actionName)) {
+				if (this.dataLoaderOptions.has(actionName)) {
 					// use any specified options assigned to this action
-					const options = dataLoaderOptions.get(actionName);
+					const options = this.dataLoaderOptions.get(actionName);
 					return new DataLoader(batchLoadFn, options);
 				}
 
@@ -577,10 +571,10 @@ module.exports = function(mixinOptions) {
 			 * Build a map of options to use with DataLoader
 			 *
 			 * @param {Object[]} services
-			 * @modifies {dataLoaderOptions}
+			 * @modifies {this.dataLoaderOptions}
 			 */
 			buildLoaderOptionMap(services) {
-				dataLoaderOptions.clear(); // clear map before rebuilding
+				this.dataLoaderOptions.clear(); // clear map before rebuilding
 
 				services.forEach(service => {
 					Object.values(service.actions).forEach(action => {
@@ -591,7 +585,7 @@ module.exports = function(mixinOptions) {
 								serviceName,
 								actionName
 							);
-							dataLoaderOptions.set(
+							this.dataLoaderOptions.set(
 								fullActionName,
 								graphqlDefinition.dataLoaderOptions
 							);
@@ -607,6 +601,7 @@ module.exports = function(mixinOptions) {
 			this.graphqlSchema = null;
 			this.pubsub = null;
 			this.shouldUpdateGraphqlSchema = true;
+			this.dataLoaderOptions = new Map();
 
 			const route = _.defaultsDeep(mixinOptions.routeOptions, {
 				aliases: {

--- a/src/service.js
+++ b/src/service.js
@@ -13,6 +13,7 @@ const DataLoader = require("dataloader");
 const { makeExecutableSchema } = require("graphql-tools");
 const GraphQL = require("graphql");
 const { PubSub, withFilter } = require("graphql-subscriptions");
+const hash = require("object-hash");
 
 module.exports = function(mixinOptions) {
 	mixinOptions = _.defaultsDeep(mixinOptions, {
@@ -24,6 +25,12 @@ module.exports = function(mixinOptions) {
 		createAction: true,
 		subscriptionEventName: "graphql.publish",
 	});
+
+	/**
+	 * DataLoader options
+	 * @type {Map<string, Object.<string, any>>} Action name key; value of options object to pass to DataLoader constructor
+	 */
+	const dataLoaderOptions = new Map();
 
 	const serviceSchema = {
 		events: {
@@ -127,7 +134,7 @@ module.exports = function(mixinOptions) {
 				const {
 					dataLoader = false,
 					nullIfError = false,
-					params = {},
+					params: staticParams = {},
 					rootParams = {},
 				} = def;
 				const rootKeys = Object.keys(rootParams);
@@ -135,27 +142,46 @@ module.exports = function(mixinOptions) {
 				return async (root, args, context) => {
 					try {
 						if (dataLoader) {
-							const dataLoaderKey = rootKeys[0]; // use the first root key
-							const rootValue = root && _.get(root, dataLoaderKey);
+							const dataLoaderMapKey = this.getDataLoaderMapKey(
+								actionName,
+								staticParams,
+								args
+							);
+							const dataLoaderRootKey = rootKeys[0]; // for dataloader, use the first root key only
+
+							// check to see if the DataLoader has already been added to the GraphQL context; if not then add it for subsequent use
+							let dataLoader;
+							if (context.dataLoaders.has(dataLoaderMapKey)) {
+								dataLoader = context.dataLoaders.get(dataLoaderMapKey);
+							} else {
+								dataLoader = this.buildDataLoader(
+									context.ctx,
+									actionName,
+									dataLoaderRootKey,
+									staticParams,
+									args
+								);
+								context.dataLoaders.set(dataLoaderMapKey, dataLoader);
+							}
+
+							const rootValue = root && _.get(root, dataLoaderRootKey);
 							if (rootValue == null) {
 								return null;
 							}
 
 							return Array.isArray(rootValue)
-								? await Promise.all(
-										rootValue.map(item =>
-											context.loaders[actionName].load(item)
-										)
-								  )
-								: await context.loaders[actionName].load(rootValue);
+								? await dataLoader.loadMany(rootValue)
+								: await dataLoader.load(rootValue);
 						} else {
-							const p = {};
+							const params = {};
 							if (root && rootKeys) {
-								rootKeys.forEach(k => _.set(p, def.rootParams[k], _.get(root, k)));
+								rootKeys.forEach(key =>
+									_.set(params, rootParams[key], _.get(root, key))
+								);
 							}
 							return await context.ctx.call(
 								actionName,
-								_.defaultsDeep(args, p, params)
+								_.defaultsDeep(args, params, staticParams)
 							);
 						}
 					} catch (err) {
@@ -169,6 +195,48 @@ module.exports = function(mixinOptions) {
 						throw err;
 					}
 				};
+			},
+
+			/**
+			 * Get the unique key assigned to the DataLoader map
+			 * @param {string} actionName - Fully qualified action name to bind to dataloader
+			 * @param {Object.<string, any>} staticParams - Static parameters to use in dataloader
+			 * @param {Object.<string, any>} args - Arguments passed to GraphQL child resolver
+			 */
+			getDataLoaderMapKey(actionName, staticParams, args) {
+				if (Object.keys(staticParams).length > 0 || Object.keys(args).length > 0) {
+					// create a unique hash of the static params and the arguments to ensure a unique DataLoader instance
+					const actionParams = _.defaultsDeep(args, staticParams);
+					const paramsHash = hash(actionParams);
+					return `${actionName}:${paramsHash}`;
+				}
+
+				// if no static params or arguments are present then the action name can serve as the key
+				return actionName;
+			},
+
+			/**
+			 * Build a DataLoader instance
+			 *
+			 * @param {Object} ctx - Moleculer context
+			 * @param {string} actionName - Fully qualified action name to bind to dataloader
+			 * @param {string} batchedParamKey - Parameter key to use for loaded values
+			 * @param {Object} staticParams - Static parameters to use in dataloader
+			 * @param {Object} args - Arguments passed to GraphQL child resolver
+			 */
+			buildDataLoader(ctx, actionName, batchedParamKey, staticParams, args) {
+				const batchLoadFn = keys => {
+					const rootParams = { [batchedParamKey]: keys };
+					return ctx.call(actionName, _.defaultsDeep(args, rootParams, staticParams));
+				};
+
+				if (dataLoaderOptions.has(actionName)) {
+					// use any specified options assigned to this action
+					const options = dataLoaderOptions.get(actionName);
+					return new DataLoader(batchLoadFn, options);
+				}
+
+				return new DataLoader(batchLoadFn);
 			},
 
 			/**
@@ -469,7 +537,7 @@ module.exports = function(mixinOptions) {
 											ctx: req.$ctx,
 											service: req.$service,
 											params: req.$params,
-											loaders: this.createLoaders(req, services),
+											dataLoaders: new Map(), // create an empty map to load DataLoader instances into
 									  }
 									: {
 											service: connection.$service,
@@ -490,6 +558,8 @@ module.exports = function(mixinOptions) {
 					this.apolloServer.installSubscriptionHandlers(this.server);
 					this.graphqlSchema = schema;
 
+					this.buildLoaderOptionMap(services); // rebuild the options for DataLoaders
+
 					this.shouldUpdateGraphqlSchema = false;
 
 					this.broker.broadcast("graphql.schema.updated", {
@@ -502,71 +572,30 @@ module.exports = function(mixinOptions) {
 			},
 
 			/**
-			 * Create the DataLoader instances to be used for batch resolution
-			 * @param {Object} req
+			 * Build a map of options to use with DataLoader
+			 *
 			 * @param {Object[]} services
-			 * @returns {Object.<string, Object>} Key/value pairs of DataLoader instances
+			 * @modifies {dataLoaderOptions}
 			 */
-			createLoaders(req, services) {
-				return services.reduce((serviceAccum, service) => {
-					const serviceName = this.getServiceName(service);
-					if (!service.settings) {
-						service.settings = {};
-					}
-					const { graphql } = service.settings;
-					if (graphql && graphql.resolvers) {
-						const { resolvers } = graphql;
+			buildLoaderOptionMap(services) {
+				dataLoaderOptions.clear(); // clear map before rebuilding
 
-						const typeLoaders = Object.values(resolvers).reduce(
-							(resolverAccum, type) => {
-								const resolverLoaders = Object.values(type).reduce(
-									(fieldAccum, resolver) => {
-										if (_.isPlainObject(resolver)) {
-											const {
-												action,
-												dataLoader = false,
-												params = {},
-												rootParams = {},
-											} = resolver;
-											const actionParam = Object.values(rootParams)[0]; // use the first root parameter
-											if (dataLoader && actionParam) {
-												const resolverActionName = this.getResolverActionName(
-													serviceName,
-													action
-												);
-												if (fieldAccum[resolverActionName] == null) {
-													// create a new DataLoader instance
-													fieldAccum[resolverActionName] = new DataLoader(
-														keys =>
-															req.$ctx.call(
-																resolverActionName,
-																_.defaultsDeep(
-																	{
-																		[actionParam]: keys,
-																	},
-																	params
-																)
-															)
-													);
-												}
-											}
-										}
-
-										return fieldAccum;
-									},
-									{}
-								);
-
-								return { ...resolverAccum, ...resolverLoaders };
-							},
-							{}
-						);
-
-						serviceAccum = { ...serviceAccum, ...typeLoaders };
-					}
-
-					return serviceAccum;
-				}, {});
+				services.forEach(service => {
+					Object.values(service.actions).forEach(action => {
+						const { graphql: graphqlDefinition, name: actionName } = action;
+						if (graphqlDefinition && graphqlDefinition.dataLoaderOptions) {
+							const serviceName = this.getServiceName(service);
+							const fullActionName = this.getResolverActionName(
+								serviceName,
+								actionName
+							);
+							dataLoaderOptions.set(
+								fullActionName,
+								graphqlDefinition.dataLoaderOptions
+							);
+						}
+					});
+				});
 			},
 		},
 

--- a/src/service.js
+++ b/src/service.js
@@ -510,8 +510,8 @@ module.exports = function(mixinOptions) {
 			createLoaders(req, services) {
 				return services.reduce((serviceAccum, service) => {
 					const serviceName = this.getServiceName(service);
-					if(!service.settings) {
-						service.settings = {}
+					if (!service.settings) {
+						service.settings = {};
 					}
 					const { graphql } = service.settings;
 					if (graphql && graphql.resolvers) {


### PR DESCRIPTION
This PR adds additional functionality to the DataLoader implementation.  The changes are indicated below:

1. The location at which the DataLoader instances are constructed has been changed.  Instead of constructing all DataLoader instances that _could_ be required at the beginning of the request, DataLoader instances are instead lazily loaded if they become necessary.  Although constructing DataLoader instances should be relatively trivial, this should provide a performance increase should there ever be a lot of resolvers that use data loaders.

2. Since the DataLoader instances are now loaded during resolution, the GraphQL `args` have now become accessible and are able to be added to the batch function provided to DataLoader.  Since the `args` are bound by closure into the DataLoader batch function, it is possible that there could be multiple DataLoader instances for a single action -- that is, if the same action is called with different arguments, multiple instances are needed.  To solve for this, the `args` and `params` are hashed to make a unique key for each DataLoader instance, and the appropriate DataLoader instance will be used.  To facilitate this, the `object-hash` package was added to the dependencies.

3. DataLoader's constructor accept options, such as `maxBatchSize`.  It seems sensible that the called action should decide these options, rather than the resolver.  Therefore, a new property has been added to the action's `graphql` property named `dataLoaderOptions`.  This should be an object that matches the API for DataLoader's [options](https://github.com/graphql/dataloader#api).  If provided, when a DataLoader is constructed to call that action, those options will be used.

4. The version of DataLoader has been bumped to the latest (2.0.0).

5. The README.md has been updated with more information on how to use DataLoader.

6. Tests were updated to ensure that DataLoader is properly calling actions in the expected fashion.