### PR TITLE
npm accept is deprecated, use @hapi/accept instead.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,28 @@
         "minimist": "^1.2.0"
       }
     },
+    "@hapi/accept": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-4.0.0.tgz",
+      "integrity": "sha512-1wfaS05XyraV4FG8GVcsATorTokAO3i3rAIzffxmqEGUct87tKkIvwtcNDfpEz6AhN77R8uPU0FO5DD3AJutHg==",
+      "requires": {
+        "@hapi/boom": "8.x.x",
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/boom": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-8.0.1.tgz",
+      "integrity": "sha512-SnBM2GzEYEA6AGFKXBqNLWXR3uNBui0bkmklYXX1gYtevVhDTy2uakwkSauxvIWMtlANGRhzChYg95If3FWCwA==",
+      "requires": {
+        "@hapi/hoek": "8.x.x"
+      }
+    },
+    "@hapi/hoek": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -1359,15 +1381,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "accept": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/accept/-/accept-3.1.3.tgz",
-      "integrity": "sha512-OgOEAidVEOKPup+Gv2+2wdH2AgVKI9LxsJ4hicdJ6cY0faUuZdZoi56kkXWlHp9qicN1nWQLmW5ZRGk+SBS5xg==",
-      "requires": {
-        "boom": "7.x.x",
-        "hoek": "6.x.x"
-      }
-    },
     "acorn": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
@@ -2245,14 +2258,6 @@
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
           "dev": true
         }
-      }
-    },
-    "boom": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.3.0.tgz",
-      "integrity": "sha512-Swpoyi2t5+GhOEGw8rEsKvTxFLIDiiKoUc2gsoV6Lyr43LHBIzch3k2MvYUs8RTROrIkVJ3Al0TkaOGjnb+B6A==",
-      "requires": {
-        "hoek": "6.x.x"
       }
     },
     "boxen": {
@@ -4791,11 +4796,6 @@
           "dev": true
         }
       }
-    },
-    "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.24",
-    "accept": "^3.1.3",
+    "@hapi/accept": "^4.0.0",
     "apollo-server-core": "^2.10.0",
     "dataloader": "^2.0.0",
     "graphql-subscriptions": "^1.1.0",

--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -3,7 +3,7 @@
 const { ApolloServerBase } = require("apollo-server-core");
 const { processRequest } = require("graphql-upload");
 const { renderPlaygroundPage } = require("@apollographql/graphql-playground-html");
-const accept = require("accept");
+const accept = require("@hapi/accept");
 const moleculerApollo = require("./moleculerApollo");
 
 function send(req, res, statusCode, data, responseType = "application/json") {


### PR DESCRIPTION
I got an warning that package `accept` is deprecated during building image, and switching to use `@hapi/accept` instead.

Run all test suites are passed. Hope you can merge and release as a patch (`v0.2.1` if possible)

 PASS  test/unit/ApolloServer.spec.js
 PASS  test/unit/index.spec.js
 PASS  test/unit/moleculerApollo.spec.js
 PASS  test/unit/service.spec.js
 PASS  test/unit/gql.spec.js
 PASS  test/integration/greeter.spec.js
--------------------|---------|----------|---------|---------|-------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
--------------------|---------|----------|---------|---------|-------------------
All files           |   98.68 |    92.82 |     100 |   98.64 |
 ApolloServer.js    |     100 |    89.29 |     100 |     100 | 57,60,101
 gql.js             |     100 |      100 |     100 |     100 |
 moleculerApollo.js |     100 |    88.24 |     100 |     100 | 52
 service.js         |   98.23 |    93.84 |     100 |   98.19 | 408,412,567,568
--------------------|---------|----------|---------|---------|-------------------

Test Suites: 6 passed, 6 total
Tests:       67 passed, 67 total
Snapshots:   1 passed, 1 total
Time:        3.727s
Ran all test suites.