### PR TITLE
Allow multiple rootParams to be used with Dataloader child resolution

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -168,11 +168,11 @@ module.exports = function(mixinOptions) {
 
 							let dataLoaderKey;
 							if (dataLoaderUseAllRootKeys) {
-								if (root) {
+								if (root && rootKeys) {
 									dataLoaderKey = {};
 
-									Object.entries(rootParams).forEach(([rootKey, paramName]) => {
-										_.set(dataLoaderKey, paramName, _.get(root, rootKey));
+									rootKeys.forEach(key => {
+										_.set(dataLoaderKey, rootParams[key], _.get(root, key));
 									});
 								}
 							} else {
@@ -188,9 +188,9 @@ module.exports = function(mixinOptions) {
 								: await dataLoader.load(dataLoaderKey);
 						} else {
 							const params = {};
-							if (root) {
-								Object.entries(rootParams).forEach(([rootKey, paramName]) => {
-									_.set(params, paramName, _.get(root, rootKey));
+							if (root && rootKeys) {
+								rootKeys.forEach(key => {
+									_.set(params, rootParams[key], _.get(root, key));
 								});
 							}
 

--- a/src/service.js
+++ b/src/service.js
@@ -618,7 +618,7 @@ module.exports = function(mixinOptions) {
 						if (
 							graphqlDefinition &&
 							(graphqlDefinition.dataLoaderOptions ||
-								graphqlDefinition.dataLoaderBatchParams)
+								graphqlDefinition.dataLoaderBatchParam)
 						) {
 							const serviceName = this.getServiceName(service);
 							const fullActionName = this.getResolverActionName(

--- a/src/service.js
+++ b/src/service.js
@@ -126,7 +126,7 @@ module.exports = function(mixinOptions) {
 			 */
 			createActionResolver(actionName, def = {}) {
 				const {
-					dataLoader = false,
+					dataLoader: useDataLoader = false,
 					nullIfError = false,
 					params: staticParams = {},
 					rootParams = {},
@@ -135,44 +135,63 @@ module.exports = function(mixinOptions) {
 
 				return async (root, args, context) => {
 					try {
-						if (dataLoader) {
+						if (useDataLoader) {
 							const dataLoaderMapKey = this.getDataLoaderMapKey(
 								actionName,
 								staticParams,
 								args
 							);
-							const dataLoaderRootKey = rootKeys[0]; // for dataloader, use the first root key only
+							// if a dataLoader batching parameter is specified, then all root params can be data loaded;
+							// otherwise use only the primary rootParam
+							const primaryDataLoaderRootKey = rootKeys[0]; // for dataloader, use the first root key only
+							const dataLoaderBatchParam = this.dataLoaderBatchParams.get(actionName);
+							const dataLoaderUseAllRootKeys = dataLoaderBatchParam != null;
 
 							// check to see if the DataLoader has already been added to the GraphQL context; if not then add it for subsequent use
 							let dataLoader;
 							if (context.dataLoaders.has(dataLoaderMapKey)) {
 								dataLoader = context.dataLoaders.get(dataLoaderMapKey);
 							} else {
-								const batchedParamKey = rootParams[dataLoaderRootKey];
+								const batchedParamKey =
+									dataLoaderBatchParam || rootParams[primaryDataLoaderRootKey];
+
 								dataLoader = this.buildDataLoader(
 									context.ctx,
 									actionName,
 									batchedParamKey,
 									staticParams,
-									args
+									args,
+									{ hashCacheKey: dataLoaderUseAllRootKeys } // must hash the cache key if not loading scalar
 								);
 								context.dataLoaders.set(dataLoaderMapKey, dataLoader);
 							}
 
-							const rootValue = root && _.get(root, dataLoaderRootKey);
-							if (rootValue == null) {
+							let dataLoaderKey;
+							if (dataLoaderUseAllRootKeys) {
+								if (root) {
+									dataLoaderKey = {};
+
+									Object.entries(rootParams).forEach(([rootKey, paramName]) => {
+										_.set(dataLoaderKey, paramName, _.get(root, rootKey));
+									});
+								}
+							} else {
+								dataLoaderKey = root && _.get(root, primaryDataLoaderRootKey);
+							}
+
+							if (dataLoaderKey == null) {
 								return null;
 							}
 
-							return Array.isArray(rootValue)
-								? await dataLoader.loadMany(rootValue)
-								: await dataLoader.load(rootValue);
+							return Array.isArray(dataLoaderKey)
+								? await dataLoader.loadMany(dataLoaderKey)
+								: await dataLoader.load(dataLoaderKey);
 						} else {
 							const params = {};
-							if (root && rootKeys) {
-								rootKeys.forEach(key =>
-									_.set(params, rootParams[key], _.get(root, key))
-								);
+							if (root) {
+								Object.entries(rootParams).forEach(([rootKey, paramName]) => {
+									_.set(params, paramName, _.get(root, rootKey));
+								});
 							}
 
 							return await context.ctx.call(
@@ -220,21 +239,31 @@ module.exports = function(mixinOptions) {
 			 * @param {string} batchedParamKey - Parameter key to use for loaded values
 			 * @param {Object} staticParams - Static parameters to use in dataloader
 			 * @param {Object} args - Arguments passed to GraphQL child resolver
+			 * @param {Object} [options={}] - Optional arguments
+			 * @param {Boolean} [options.hashCacheKey=false] - Use a hash for the cacheKeyFn
 			 * @returns {DataLoader} Dataloader instance
 			 */
-			buildDataLoader(ctx, actionName, batchedParamKey, staticParams, args) {
+			buildDataLoader(
+				ctx,
+				actionName,
+				batchedParamKey,
+				staticParams,
+				args,
+				{ hashCacheKey = false } = {}
+			) {
 				const batchLoadFn = keys => {
 					const rootParams = { [batchedParamKey]: keys };
 					return ctx.call(actionName, _.defaultsDeep({}, args, rootParams, staticParams));
 				};
 
-				if (this.dataLoaderOptions.has(actionName)) {
-					// use any specified options assigned to this action
-					const options = this.dataLoaderOptions.get(actionName);
-					return new DataLoader(batchLoadFn, options);
-				}
+				const dataLoaderOptions = this.dataLoaderOptions.get(actionName) || {};
+				const cacheKeyFn = hashCacheKey && (key => hash(key));
+				const options = {
+					...(cacheKeyFn && { cacheKeyFn }),
+					...dataLoaderOptions,
+				};
 
-				return new DataLoader(batchLoadFn);
+				return new DataLoader(batchLoadFn, options);
 			},
 
 			/**
@@ -574,23 +603,39 @@ module.exports = function(mixinOptions) {
 			 *
 			 * @param {Object[]} services
 			 * @modifies {this.dataLoaderOptions}
+			 * @modifies {this.dataLoaderBatchParams}
 			 */
 			buildLoaderOptionMap(services) {
 				this.dataLoaderOptions.clear(); // clear map before rebuilding
+				this.dataLoaderBatchParams.clear(); // clear map before rebuilding
 
 				services.forEach(service => {
 					Object.values(service.actions).forEach(action => {
 						const { graphql: graphqlDefinition, name: actionName } = action;
-						if (graphqlDefinition && graphqlDefinition.dataLoaderOptions) {
+						if (
+							graphqlDefinition &&
+							(graphqlDefinition.dataLoaderOptions ||
+								graphqlDefinition.dataLoaderBatchParams)
+						) {
 							const serviceName = this.getServiceName(service);
 							const fullActionName = this.getResolverActionName(
 								serviceName,
 								actionName
 							);
-							this.dataLoaderOptions.set(
-								fullActionName,
-								graphqlDefinition.dataLoaderOptions
-							);
+
+							if (graphqlDefinition.dataLoaderOptions) {
+								this.dataLoaderOptions.set(
+									fullActionName,
+									graphqlDefinition.dataLoaderOptions
+								);
+							}
+
+							if (graphqlDefinition.dataLoaderBatchParam) {
+								this.dataLoaderBatchParams.set(
+									fullActionName,
+									graphqlDefinition.dataLoaderBatchParam
+								);
+							}
 						}
 					});
 				});
@@ -604,6 +649,7 @@ module.exports = function(mixinOptions) {
 			this.pubsub = null;
 			this.shouldUpdateGraphqlSchema = true;
 			this.dataLoaderOptions = new Map();
+			this.dataLoaderBatchParams = new Map();
 
 			const route = _.defaultsDeep(mixinOptions.routeOptions, {
 				aliases: {

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -521,6 +521,7 @@ describe("Test Service", () => {
 
 		beforeEach(() => {
 			svc.dataLoaderOptions.clear();
+			svc.dataLoaderBatchParams.clear();
 		});
 
 		it("should return null if no rootValue", async () => {
@@ -608,6 +609,79 @@ describe("Test Service", () => {
 			expect(ctx.call).toHaveBeenCalledTimes(2);
 			expect(ctx.call).toHaveBeenNthCalledWith(1, "users.resolve", { a: 5, id: [1, 2] });
 			expect(ctx.call).toHaveBeenNthCalledWith(2, "users.resolve", { a: 5, id: [5] });
+		});
+
+		it("should call the action via the loader using all root params", async () => {
+			svc.dataLoaderBatchParams.set("users.resolve", "testBatchParam");
+			const resolver = svc.createActionResolver("users.resolve", {
+				rootParams: {
+					authorId: "authorIdParam",
+					testId: "testIdParam",
+				},
+
+				dataLoader: true,
+			});
+
+			const ctx = new Context(broker);
+			ctx.call = jest.fn().mockResolvedValue(["res1", "res2", "res3"]);
+
+			const fakeRoot1 = { authorId: 1, testId: "foo" };
+			const fakeRoot2 = { authorId: 2, testId: "bar" };
+			const fakeRoot3 = { authorId: 5, testId: "baz" };
+
+			const fakeContext = { ctx, dataLoaders: new Map() };
+			const res = await Promise.all([
+				resolver(fakeRoot1, {}, fakeContext),
+				resolver(fakeRoot2, {}, fakeContext),
+				resolver(fakeRoot3, {}, fakeContext),
+			]);
+
+			expect(res).toEqual(["res1", "res2", "res3"]);
+
+			expect(ctx.call).toHaveBeenCalledTimes(1);
+			expect(ctx.call).toHaveBeenNthCalledWith(1, "users.resolve", {
+				testBatchParam: [
+					{ authorIdParam: 1, testIdParam: "foo" },
+					{ authorIdParam: 2, testIdParam: "bar" },
+					{ authorIdParam: 5, testIdParam: "baz" },
+				],
+			});
+		});
+
+		it("should call the action via the loader using all root params while leveraging cache", async () => {
+			svc.dataLoaderBatchParams.set("users.resolve", "testBatchParam");
+			const resolver = svc.createActionResolver("users.resolve", {
+				rootParams: {
+					authorId: "authorIdParam",
+					testId: "testIdParam",
+				},
+
+				dataLoader: true,
+			});
+
+			const ctx = new Context(broker);
+			ctx.call = jest.fn().mockResolvedValue(["res1", "res2"]);
+
+			const fakeRoot1 = { authorId: 1, testId: "foo" };
+			const fakeRoot2 = { authorId: 2, testId: "bar" };
+			const fakeRoot3 = { authorId: 1, testId: "foo" }; // same as fakeRoot1
+
+			const fakeContext = { ctx, dataLoaders: new Map() };
+			const res = await Promise.all([
+				resolver(fakeRoot1, {}, fakeContext),
+				resolver(fakeRoot2, {}, fakeContext),
+				resolver(fakeRoot3, {}, fakeContext),
+			]);
+
+			expect(res).toEqual(["res1", "res2", "res1"]);
+
+			expect(ctx.call).toHaveBeenCalledTimes(1);
+			expect(ctx.call).toHaveBeenNthCalledWith(1, "users.resolve", {
+				testBatchParam: [
+					{ authorIdParam: 1, testIdParam: "foo" },
+					{ authorIdParam: 2, testIdParam: "bar" },
+				],
+			});
 		});
 
 		it("should reuse the loader for multiple calls with the same context", async () => {
@@ -1144,7 +1218,10 @@ describe("Test Service", () => {
 					actions: [
 						{
 							name: "test-action-1",
-							graphql: { dataLoaderOptions: { option1: "option-value-1" } },
+							graphql: {
+								dataLoaderOptions: { option1: "option-value-1" },
+								dataLoaderBatchParam: "batch-param-1",
+							},
 						},
 						{ name: "test-action-2" },
 					],
@@ -1155,7 +1232,10 @@ describe("Test Service", () => {
 					actions: [
 						{
 							name: "test-action-3",
-							graphql: { dataLoaderOptions: { option2: "option-value-2" } },
+							graphql: {
+								dataLoaderOptions: { option2: "option-value-2" },
+								dataLoaderBatchParam: "batch-param-2",
+							},
 						},
 						{ name: "test-action-4" },
 					],
@@ -1220,6 +1300,13 @@ describe("Test Service", () => {
 				new Map([
 					["test-svc-1.test-action-1", { option1: "option-value-1" }],
 					["v1.test-svc-2.test-action-3", { option2: "option-value-2" }],
+				])
+			);
+
+			expect(svc.dataLoaderBatchParams).toEqual(
+				new Map([
+					["test-svc-1.test-action-1", "batch-param-1"],
+					["v1.test-svc-2.test-action-3", "batch-param-2"],
 				])
 			);
 

--- a/test/unit/service.spec.js
+++ b/test/unit/service.spec.js
@@ -210,7 +210,7 @@ describe("Test Service", () => {
 
 		it("should not invalidate schema when autoUpdateSchema is false", async () => {
 			const { broker, svc, stop } = await startService({
-				autoUpdateSchema: false
+				autoUpdateSchema: false,
 			});
 			svc.invalidateGraphQLSchema = jest.fn();
 
@@ -223,7 +223,7 @@ describe("Test Service", () => {
 
 		it("should not invalidate schema when autoUpdateSchema is true", async () => {
 			const { broker, svc, stop } = await startService({
-				autoUpdateSchema: true
+				autoUpdateSchema: true,
 			});
 			svc.invalidateGraphQLSchema = jest.fn();
 


### PR DESCRIPTION
The purpose of this PR is to allow specification of multiple `rootParams` properties to be provided for child resolution while using Dataloader.

A fundamental premise of Dataloader is that only a single "key" can be loaded.  This key can be any type, including objects, provided that the Dataloader can properly cache those keys.  In the current implementation of Dataloader, only a single property from `rootParams` can be loaded, since there was no effective way to declare how an object should be loaded on to the called action params.

This PR allows for specification of a new property in the action schema's `graphql` definition named `dataLoaderBatchParam`.  If this property is specified, then the data which is pulled from the parent (root) will be loaded into an object with the specified property name, rather than passed as a parameter with that name.  For instance, without Dataloader, a child resolution structure like:

```
Item: {
  group: {
    action: 'group.get',
    rootParams: {
      parentId: 'groupParentId',
      childId: 'groupChildId',
    }
  }
}
```
would call an action with signature `ctx.call('group.get', { groupParentId: ROOT_PARENTID, groupChildId: ROOT_CHILDID });`

However, with Dataloader enabled, that same structure would call an action with signature `ctx.call('group.get', { groupParentId: [ROOT_PARENTID] });` with the data being batched and loaded into an array and the second specified parameter being dropped.

With this change, if the `group.get` action has, in its action schema, `graphql: { dataLoaderBatchParam: 'myBatchParam' }`, that will instead get called with signature `ctx.call('group.get', { myBatchParam: [{ groupParentId: ROOT_PARENTID, groupChildId: ROOT_CHILDID }] });`.  If multiple "keys" are data loaded, the `myBatchParam` array will have multiple objects passed to it.

To facilitate proper caching of these objects, a custom `cacheKeyFn` has been passed to the Dataloader constructor which will hash the objects to provide a unique ID of the value of the objects since Dataloader would otherwise use an equality check which would only match the objects by reference.

The rationale for defining this parameter name in the action schema instead of the child resolution definition is that it would be highly unusual for different resolutions calling the same action to use a different batching parameter, thus, all resolutions calling the same action would use the same batching parameter.  Rather than defining that every time you wanted to child resolve via that action, the parameter only needs to be defined once in the action definition.


