### PR TITLE
Transform Uploads to Streams before calling action

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ module.exports = {
                 }
                 const fileContents = Buffer.concat(fileChunks);
                 // Do something with file contents
-                return ctx.params.$fileInfo;
+                return ctx.meta.$fileInfo;
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ It is unlikely that setting any of the options which accept a function will work
 
 - [Simple](examples/simple/index.js)
   - `npm run dev`
+- [File Upload](examples/upload/index.js)
+  - `npm run dev upload`
+  - See [here](https://github.com/jaydenseric/graphql-multipart-request-spec#curl-request) for information about how to create a file upload request
 - [Full](examples/full/index.js)
   - `npm run dev full`
 - [Full With Dataloader](examples/full/index.js)

--- a/examples/upload/index.js
+++ b/examples/upload/index.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const { ServiceBroker } = require("moleculer");
+
+const ApiGateway = require("moleculer-web");
+const { ApolloService, GraphQLUpload } = require("../../index");
+
+const broker = new ServiceBroker({ logLevel: "info", hotReload: true });
+
+broker.createService({
+	name: "api",
+
+	mixins: [
+		// Gateway
+		ApiGateway,
+
+		// GraphQL Apollo Server
+		ApolloService({
+			typeDefs: ["scalar Upload"],
+			resolvers: {
+				Upload: GraphQLUpload,
+			},
+			// API Gateway route options
+			routeOptions: {
+				path: "/graphql",
+				cors: true,
+				mappingPolicy: "restrict",
+			},
+
+			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
+			serverOptions: {},
+		}),
+	],
+
+	events: {
+		"graphql.schema.updated"({ schema }) {
+			this.logger.info("Generated GraphQL schema:\n\n" + schema);
+		},
+	},
+});
+
+broker.createService({
+	name: "files",
+	settings: {
+		graphql: {
+			type: `
+                """
+                This type describes a File entity.
+                """
+                type File {
+                    filename: String!
+                    encoding: String!
+                    mimetype: String!
+                }
+            `,
+		},
+	},
+	actions: {
+		hello: {
+			graphql: {
+				query: "hello: String!",
+			},
+			handler() {
+				return "Hello Moleculer!";
+			},
+		},
+		singleUpload: {
+			graphql: {
+				mutation: "singleUpload(file: Upload!): File!",
+				fileUploadArg: "file",
+			},
+			async handler(ctx) {
+				const fileChunks = [];
+				for await (const chunk of ctx.params) {
+					fileChunks.push(chunk);
+				}
+				const fileContents = Buffer.concat(fileChunks);
+				ctx.broker.logger.info("Uploaded File Contents:");
+				ctx.broker.logger.info(fileContents.toString());
+				return ctx.meta.$fileInfo;
+			},
+		},
+	},
+});
+
+broker.start().then(async () => {
+	broker.repl();
+
+	broker.logger.info("----------------------------------------------------------");
+	broker.logger.info("For information about creating a file upload request,");
+	broker.logger.info(
+		"see https://github.com/jaydenseric/graphql-multipart-request-spec#curl-request"
+	);
+	broker.logger.info("----------------------------------------------------------");
+});

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@ declare module "moleculer-apollo-server" {
 	import { SchemaDirectiveVisitor, IResolvers } from "graphql-tools";
 
 	export {
-		GraphQLUpload,
 		GraphQLExtension,
 		gql,
 		ApolloError,
@@ -17,6 +16,8 @@ declare module "moleculer-apollo-server" {
 		UserInputError,
 		defaultPlaygroundOptions,
 	} from "apollo-server-core";
+
+	export { GraphQLUpload } from 'graphql-upload';
 
 	export * from "graphql-tools";
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const gql = require("./src/gql");
 
 module.exports = {
 	// Core
-	GraphQLUpload: GraphQLUpload,
+	GraphQLUpload,
 	GraphQLExtension: core.GraphQLExtension,
 	gql: core.gql,
 	ApolloError: core.ApolloError,

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ const gql = require("./src/gql");
 
 module.exports = {
 	// Core
-	GraphQLUpload,
 	GraphQLExtension: core.GraphQLExtension,
 	gql: core.gql,
 	ApolloError: core.ApolloError,
@@ -36,6 +35,9 @@ module.exports = {
 
 	// GraphQL tools
 	...require("graphql-tools"),
+
+	// GraphQL Upload
+	GraphQLUpload,
 
 	// Apollo Server
 	ApolloServer,

--- a/index.js
+++ b/index.js
@@ -15,13 +15,14 @@
 "use strict";
 
 const core = require("apollo-server-core");
+const { GraphQLUpload } = require("graphql-upload");
 const { ApolloServer } = require("./src/ApolloServer");
 const ApolloService = require("./src/service");
 const gql = require("./src/gql");
 
 module.exports = {
 	// Core
-	GraphQLUpload: core.GraphQLUpload,
+	GraphQLUpload: GraphQLUpload,
 	GraphQLExtension: core.GraphQLExtension,
 	gql: core.gql,
 	ApolloError: core.ApolloError,

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@apollographql/graphql-playground-html": "^1.6.24",
     "@hapi/accept": "^3.2.4",
+    "@types/graphql-upload": "^8.0.0",
     "apollo-server-core": "^2.10.0",
     "dataloader": "^2.0.0",
     "graphql-subscriptions": "^1.1.0",

--- a/src/service.js
+++ b/src/service.js
@@ -412,7 +412,7 @@ module.exports = function(mixinOptions) {
 						const resolver = {};
 
 						Object.values(service.actions).forEach(action => {
-							const { graphql: def, fileUploadArg } = action;
+							const { graphql: def } = action;
 							if (def && _.isObject(def)) {
 								if (def.query) {
 									if (!resolver["Query"]) resolver.Query = {};
@@ -435,7 +435,7 @@ module.exports = function(mixinOptions) {
 										resolver.Mutation[name] = this.createActionResolver(
 											action.name,
 											{
-												fileUploadArg,
+												fileUploadArg: def.fileUploadArg,
 											}
 										);
 									});

--- a/src/service.js
+++ b/src/service.js
@@ -199,7 +199,7 @@ module.exports = function(mixinOptions) {
 											...$fileInfo
 										} = await uploadPromise;
 										const stream = createReadStream();
-										return await context.ctx.call(actionName, stream, {
+										return context.ctx.call(actionName, stream, {
 											meta: { $fileInfo },
 										});
 									})


### PR DESCRIPTION
Hello 👋 I am currently working on accepting file uploads with moleculer-apollo-server. In the process, I discovered a couple pain points which I would like to propose solutions for. These changes will result in a minor API change.

### Problem 1
In `ApolloServer.js`, the `processRequest` function is being imported from v10 of `graphql-upload`. The output from the `processRequest` function then ends up passing through the `GraphQLUpload` scalar implementation, which is re-exported from `apollo-server-core` in `index.js`. The problem is that `apollo-server-core` is using v8 of `graphql-upload`. Since the output of v10 `processRequest` does not match the expected input of v8 `GraphQLUpload`, the action ends up receiving the wrong data.

### Proposed solution to Problem 1
In `index.js`, we could re-export `GraphQLUpload` from the `graphql-upload` package instead of from `apollo-server-core`. This should ensure that both `processRequest` and `GraphQLUpload` are coming from the same version of `graphql-upload`. 

### Problem 2
When uploading a file, the action receives a parameter in the following format (assuming Problem 1 has been fixed):
```
{
  filename: string
  encoding: string
  mimetype: string
  createReadStream: function
}
```

Calling the `createReadStream` function will return a readable Stream which can be used to read the contents of the uploaded file. Unfortunately since functions are not serializable, file uploads do not work across the transporter. 

### Proposed solution to Problem 2
Moleculer supports passing streams to actions, so in `service.js` `createActionResolver`, we could transform the file upload into a stream before calling the action. This should allow file uploads to actions in separate nodes.  
Since we have no way to tell which arguments are uploads, we could allow the consumer to specify the name of the argument which is expected to be a file upload (I named this option `fileUploadArg`).  
Unfortunately this solution creates a couple sub-problems, discussed below.

#### Subproblem 2.1
When a stream is passed to an action, that action cannot accept any other parameters. So we can get the file contents to the action, but `filename`, `encoding`, and `mimetype` get lost.

#### Proposed solution to Subproblem 2.1
We can put `filename`, `encoding`, and `mimetype` into `ctx.meta` so that the action still has access to that data (I used a property called `ctx.meta.$fileInfo`).

#### Subproblem 2.2
`graphql-upload` allows uploading multiple files in a single mutation. But moleculer actions can only receive a single stream. 

#### Proposed solution to Subproblem 2.2
If the `fileUploadArg` is an array, then we can call the action once per array element, and combine the results into a result array. This would allow multiple file uploads in a single mutation.

Thank you!