### PR TITLE
[fix issue #64] No longer installing subscription handlers when disabled

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -610,7 +610,12 @@ module.exports = function(mixinOptions) {
 					this.graphqlHandler = this.apolloServer.createHandler(
 						mixinOptions.serverOptions
 					);
-					this.apolloServer.installSubscriptionHandlers(this.server);
+
+					if (mixinOptions.serverOptions.subscriptions !== false) {
+						// Avoid installing the subscription handlers if they have been disabled
+						this.apolloServer.installSubscriptionHandlers(this.server);
+					}
+
 					this.graphqlSchema = schema;
 
 					this.buildLoaderOptionMap(services); // rebuild the options for DataLoaders


### PR DESCRIPTION
The mixin always installs the apollo subscription handlers 
1. when there is no server
2. subscriptions are disabled
 
See issue https://github.com/moleculerjs/moleculer-apollo-server/issues/64

Fix checks to see if `serverOptions.subscriptions !== false` before installing. This should enable starting an apollo gateway without subscriptions. Should also allow for tests to be run against the api without a server using supertest