### PR TITLE
override timeout settings of ws connections

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -30,6 +30,7 @@ module.exports = function (mixinOptions) {
 	const serviceSchema = {
 		actions: {
 			ws: {
+				timeout: 0,
 				visibility: "private",
 				tracing: {
 					tags: {


### PR DESCRIPTION
It's usual use-case to apply requestTimeout globally via moleculer.config.js, yet expected default behavior for subscriptions is to live as long as it needs. If anything else is desired, developer can override this again within his api-service.