### PR TITLE
Add onAfterCall support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module "moleculer-apollo-server" {
 			fallbackResponse?: any;
 		};
 		onBeforeCall?: (ctx: Context, route: any, req: any, res: any) => Promise<any>;
-		onAfterCall?: (ctx: Context, route: any, req: any, res: any) => Promise<any>;
+		onAfterCall?: (ctx: Context, route: any, req: any, res: any, data: any) => Promise<any>;
 	}
 
 	export interface ApolloServiceOptions {

--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -18,7 +18,6 @@ async function send(req, res, statusCode, data, responseType = "application/json
 	if (route.onAfterCall) {
 		data = await route.onAfterCall.call(this, ctx, route, req, res, data);
 	}
-	
 
 	const service = res.$service;
 	service.sendResponse(req, res, data);
@@ -69,14 +68,14 @@ class ApolloServer extends ApolloServerBase {
 							endpoint: this.graphqlPath,
 							subscriptionEndpoint: this.subscriptionsPath,
 						},
-						this.playgroundOptions,
+						this.playgroundOptions
 					);
 					return send(
 						req,
 						res,
 						200,
 						renderPlaygroundPage(middlewareOptions),
-						"text/html",
+						"text/html"
 					);
 				}
 			}
@@ -84,7 +83,7 @@ class ApolloServer extends ApolloServerBase {
 			// Handle incoming GraphQL requests using Apollo Server.
 			const graphqlHandler = moleculerApollo(() => this.createGraphQLServerOptions(req, res));
 			const responseData = await graphqlHandler(req, res);
-			send(req, res, 200, responseData);
+			return send(req, res, 200, responseData);
 		};
 	}
 
@@ -102,10 +101,10 @@ class ApolloServer extends ApolloServerBase {
 		onHealthCheck = onHealthCheck || (() => undefined);
 		try {
 			const result = await onHealthCheck(req);
-			send(req, res, 200, { status: "pass", result }, "application/health+json");
+			return send(req, res, 200, { status: "pass", result }, "application/health+json");
 		} catch (error) {
 			const result = error instanceof Error ? error.toString() : error;
-			send(req, res, 503, { status: "fail", result }, "application/health+json");
+			return send(req, res, 503, { status: "fail", result }, "application/health+json");
 		}
 	}
 }

--- a/src/ApolloServer.js
+++ b/src/ApolloServer.js
@@ -6,13 +6,19 @@ const { renderPlaygroundPage } = require("@apollographql/graphql-playground-html
 const accept = require("@hapi/accept");
 const moleculerApollo = require("./moleculerApollo");
 
-function send(req, res, statusCode, data, responseType = "application/json") {
+async function send(req, res, statusCode, data, responseType = "application/json") {
 	res.statusCode = statusCode;
 
 	const ctx = res.$ctx;
 	if (!ctx.meta.$responseType) {
 		ctx.meta.$responseType = responseType;
 	}
+
+	const route = res.$route;
+	if (route.onAfterCall) {
+		data = await route.onAfterCall.call(this, ctx, route, req, res, data);
+	}
+	
 
 	const service = res.$service;
 	service.sendResponse(req, res, data);

--- a/test/unit/ApolloServer.spec.js
+++ b/test/unit/ApolloServer.spec.js
@@ -17,17 +17,17 @@ const ApolloServer = require("../../src/ApolloServer").ApolloServer;
 //ApolloServerCore.convertNodeHttpToRequest.mockImplementation(() => "convertedRequest");
 
 describe("Test ApolloServer", () => {
-	it("should support Uploads", () => {
+	test("should support Uploads", () => {
 		const apolloServer = new ApolloServer({});
 		expect(apolloServer.supportsUploads()).toBe(true);
 	});
 
-	it("should support subscriptions", () => {
+	test("should support subscriptions", () => {
 		const apolloServer = new ApolloServer({});
 		expect(apolloServer.supportsSubscriptions()).toBe(true);
 	});
 
-	it("should call super graphQLServerOptions", () => {
+	test("should call super graphQLServerOptions", () => {
 		const apolloServer = new ApolloServer({});
 		ApolloServerBase.prototype.graphQLServerOptions = jest.fn();
 
@@ -54,9 +54,10 @@ describe("Test ApolloServer", () => {
 		const fakeRes = {
 			$ctx: fakeCtx,
 			$service: fakeService,
+			$route: {},
 		};
 
-		it("should return 200 'pass'", async () => {
+		test("should return 200 'pass'", async () => {
 			const onHealthCheck = jest.fn(() => "Everything OK");
 
 			await apolloServer.handleHealthCheck({ req: fakeReq, res: fakeRes, onHealthCheck });
@@ -75,7 +76,7 @@ describe("Test ApolloServer", () => {
 			expect(fakeCtx.meta.$responseType).toBe("application/health+json");
 		});
 
-		it("should return 503 'fail'", async () => {
+		test("should return 503 'fail'", async () => {
 			fakeService.sendResponse.mockClear();
 
 			const onHealthCheck = jest.fn(() => Promise.reject(new Error("Something wrong")));
@@ -96,7 +97,7 @@ describe("Test ApolloServer", () => {
 			expect(fakeCtx.meta.$responseType).toBe("application/health+json");
 		});
 
-		it("should call an empty healthcheck function", async () => {
+		test("should call an empty healthcheck function", async () => {
 			fakeService.sendResponse.mockClear();
 			fakeCtx.meta.$responseType = "application/json";
 
@@ -130,15 +131,21 @@ describe("Test ApolloServer", () => {
 			sendResponse: jest.fn(),
 		};
 
-		let fakeReq = {
-			headers: {},
-		};
-		let fakeRes = {
-			$ctx: fakeCtx,
-			$service: fakeService,
-		};
+		let fakeReq;
+		let fakeRes;
 
-		it("should handle as a request", async () => {
+		beforeEach(() => {
+			fakeReq = {
+				headers: {},
+			};
+			fakeRes = {
+				$ctx: fakeCtx,
+				$service: fakeService,
+				$route: {},
+			};
+		});
+
+		test("should handle as a request", async () => {
 			const handler = apolloServer.createHandler();
 
 			await handler(fakeReq, fakeRes);
@@ -155,7 +162,7 @@ describe("Test ApolloServer", () => {
 			expect(fakeService.sendResponse).toBeCalledWith(
 				fakeReq,
 				fakeRes,
-				"GraphQL Response Data",
+				"GraphQL Response Data"
 			);
 
 			expect(fakeCtx.meta.$responseType).toBe("application/json");
@@ -166,7 +173,25 @@ describe("Test ApolloServer", () => {
 			expect(apolloServer.createGraphQLServerOptions).toBeCalledWith(fakeReq, fakeRes);
 		});
 
-		it("should handle as a file upload request", async () => {
+		test("should call onAfterCall function", async () => {
+			const handler = apolloServer.createHandler();
+			const onAfterCall = jest.fn();
+			const $route = { onAfterCall };
+			fakeRes.$route = $route;
+
+			await handler(fakeReq, fakeRes);
+
+			expect(onAfterCall).toHaveBeenCalledTimes(1);
+			expect(onAfterCall).toHaveBeenCalledWith(
+				fakeCtx,
+				$route,
+				fakeReq,
+				fakeRes,
+				"GraphQL Response Data"
+			);
+		});
+
+		test("should handle as a file upload request", async () => {
 			// Clear mocks
 			moleculerApollo.mockClear();
 			fakeGraphqlHandler.mockClear();
@@ -190,7 +215,7 @@ describe("Test ApolloServer", () => {
 			expect(GraphqlUpload.processRequest).toBeCalledWith(
 				fakeReq,
 				fakeRes,
-				apolloServer.uploadsConfig,
+				apolloServer.uploadsConfig
 			);
 
 			expect(moleculerApollo).toBeCalledTimes(1);
@@ -205,13 +230,13 @@ describe("Test ApolloServer", () => {
 			expect(fakeService.sendResponse).toBeCalledWith(
 				fakeReq,
 				fakeRes,
-				"GraphQL Response Data",
+				"GraphQL Response Data"
 			);
 
 			expect(fakeCtx.meta.$responseType).toBe("application/json");
 		});
 
-		it("should handle as health-check request", async () => {
+		test("should handle as health-check request", async () => {
 			// Clear mocks
 			moleculerApollo.mockClear();
 			fakeGraphqlHandler.mockClear();
@@ -241,7 +266,7 @@ describe("Test ApolloServer", () => {
 			expect(moleculerApollo).toBeCalledTimes(0);
 		});
 
-		it("should not handle as health-check request if disabled", async () => {
+		test("should not handle as health-check request if disabled", async () => {
 			// Clear mocks
 			moleculerApollo.mockClear();
 			fakeGraphqlHandler.mockClear();
@@ -265,7 +290,7 @@ describe("Test ApolloServer", () => {
 			expect(moleculerApollo).toBeCalledTimes(1);
 		});
 
-		it("should handle as playground request", async () => {
+		test("should handle as playground request", async () => {
 			// Clear mocks
 			moleculerApollo.mockClear();
 			fakeService.sendResponse.mockClear();


### PR DESCRIPTION
This PR amends #93 to correct potential issues with async method handling and adds tests.

`moleculer-web` allows for use of `onAfterCall` in the route definitions to call a function after processing has completed on the route.  This logic is not executed in `moleculer-apollo-server` presently since `moleculer-apollo-server` relies on a method call rather than an action call for processing the route handler.

This PR adds handling to allow for methods defined this way to be called.

Closes #92.