### PR TITLE
Fix CORS methods type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module "moleculer-apollo-server" {
 		defaultPlaygroundOptions,
 	} from "apollo-server-core";
 
-	export { GraphQLUpload } from 'graphql-upload';
+	export { GraphQLUpload } from "graphql-upload";
 
 	export * from "graphql-tools";
 
@@ -50,9 +50,11 @@ declare module "moleculer-apollo-server" {
 		};
 	}
 
+	type CorsMethods = "GET" | "POST" | "PUT" | "DELETE" | "OPTIONS";
+
 	export interface ServiceRouteCorsOptions {
 		origin?: string | string[];
-		methods?: ("GET" | "POST" | "PUT" | "DELETE" | "OPTIONS")[];
+		methods?: CorsMethods | CorsMethods[];
 		allowedHeaders?: string[];
 		exposedHeaders?: string[];
 		credentials?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module "moleculer-apollo-server" {
 
 	export interface ServiceRouteCorsOptions {
 		origin?: string | string[];
-		methods?: "GET" | "POST" | "PUT" | "DELETE" | "OPTIONS"[];
+		methods?: ("GET" | "POST" | "PUT" | "DELETE" | "OPTIONS")[];
 		allowedHeaders?: string[];
 		exposedHeaders?: string[];
 		credentials?: boolean;


### PR DESCRIPTION
This fixes the type definition when attempting to specify anything but the `"OPTIONS"` method in `ServiceRouteCorsOptions.methods`. 