### PR TITLE
add checkActionVisibility option

### DIFF
--- a/examples/simple/index.js
+++ b/examples/simple/index.js
@@ -24,6 +24,8 @@ broker.createService({
 				mappingPolicy: "restrict",
 			},
 
+			checkActionVisibility: true,
+
 			// https://www.apollographql.com/docs/apollo-server/v2/api/apollo-server.html
 			serverOptions: {},
 		}),
@@ -76,6 +78,26 @@ broker.createService({
 			},
 			async handler() {
 				throw new MoleculerClientError("I've said it's a danger action!", 422, "DANGER");
+			},
+		},
+
+		secret: {
+			visibility: "protected",
+			graphql: {
+				query: "secret: String!",
+			},
+			async handler() {
+				return "! TOP SECRET !";
+			},
+		},
+
+		visible: {
+			visibility: "published",
+			graphql: {
+				query: "visible: String!",
+			},
+			async handler() {
+				return "Not secret";
 			},
 		},
 	},

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ declare module "moleculer-apollo-server" {
 		};
 		dataLoader?: boolean;
 		nullIfError?: boolean;
+		skipNullKeys?: boolean;
 		params?: { [key: string]: any };
 	}
 
@@ -94,6 +95,7 @@ declare module "moleculer-apollo-server" {
 		};
 		routeOptions?: ServiceRouteOptions;
 		serverOptions?: Config;
+		checkActionVisibility?: boolean;
 		autoUpdateSchema?: boolean;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5632,13 +5632,19 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001415",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
+      "integrity": "sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -17890,9 +17896,9 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001255",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-      "integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ=="
+      "version": "1.0.30001415",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
+      "integrity": "sha512-ER+PfgCJUe8BqunLGWd/1EY4g8AzQcsDAVzdtMGKVtQEmKAwaFfU6vb7EAVIqTMYsqxBorYZi2+22Iouj/y7GQ=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/src/service.js
+++ b/src/service.js
@@ -25,6 +25,7 @@ module.exports = function (mixinOptions) {
 		createAction: true,
 		subscriptionEventName: "graphql.publish",
 		autoUpdateSchema: true,
+		checkActionVisibility: false,
 	});
 
 	const serviceSchema = {
@@ -450,6 +451,13 @@ module.exports = function (mixinOptions) {
 
 						Object.values(service.actions).forEach(action => {
 							const { graphql: def } = action;
+							if (
+								mixinOptions.checkActionVisibility &&
+								action.visibility != null &&
+								action.visibility != "published"
+							)
+								return;
+
 							if (def && _.isObject(def)) {
 								if (def.query) {
 									if (!resolver["Query"]) resolver.Query = {};


### PR DESCRIPTION
The new `checkActionVisibility: true` mixin option enables to service to check the `visibility` property of actions and only generate graphql query/mutations if `visibility: null` or `visibility: "published"` (same as in `moleculer-web`).

**Example**

```js
module.exports = {
    name: "api",

    mixins: [
        // Gateway
        ApiGateway,

        // GraphQL Apollo Server
        ApolloService({
            routeOptions: {},
            serverOptions: {},
    
            // Enable visibility check
            checkActionVisibility: true
        })
    ]
};
```