### PR TITLE
Await graphql handler to avoid unhandled promise rejections

### DIFF
--- a/src/service.js
+++ b/src/service.js
@@ -770,7 +770,7 @@ module.exports = function (mixinOptions) {
 					async "/"(req, res) {
 						try {
 							await this.prepareGraphQLSchema();
-							return this.graphqlHandler(req, res);
+							return await this.graphqlHandler(req, res);
 						} catch (err) {
 							this.sendError(req, res, err);
 						}
@@ -778,6 +778,7 @@ module.exports = function (mixinOptions) {
 					async "GET /.well-known/apollo/server-health"(req, res) {
 						try {
 							await this.prepareGraphQLSchema();
+							return await this.graphqlHandler(req, res);
 						} catch (err) {
 							res.statusCode = 503;
 							return this.sendResponse(
@@ -787,7 +788,6 @@ module.exports = function (mixinOptions) {
 								{ responseType: "application/health+json" }
 							);
 						}
-						return this.graphqlHandler(req, res);
 					},
 				},
 


### PR DESCRIPTION
There are scenarios where the `graphqlHandler` function can reject.  Notably, I have seen this when supplying an improperly formatted multipart request (e.g. invalid json). However, because the call to the graphql handler is not awaited, the `catch` which handles the error will not be invoked.  Instead, this error will bubble out to `moleculer-web` which does not properly handle the rejected promise.  This leads to an unhandled promise rejection in Node and, depending on node version, a hard failure of the NodeJS process.

The solution is to simply await the execution of the graphql handler. In this case, if the handler rejects, then the `catch` will be properly invoked and there will not be an unhandled promise rejection.